### PR TITLE
ui: move root implementation label to the header top-right

### DIFF
--- a/zygiskd/webui/src/App.vue
+++ b/zygiskd/webui/src/App.vue
@@ -1,15 +1,19 @@
 <script setup lang="ts">
+import { useRoot } from "./composables/useRoot";
 import FnSection from "./components/FnSection.vue";
 import LogsSection from "./components/LogsSection.vue";
 import ModulesSection from "./components/ModulesSection.vue";
 import SettingsSection from "./components/SettingsSection.vue";
 import StatusSection from "./components/StatusSection.vue";
+
+const { root } = useRoot();
 </script>
 
 <template>
   <header class="app-header">
     <div class="header-icon"><img src="/tux.png" alt="Tux" width="36" height="36"></div>
     <h1 class="header-title">OnyxZygisk</h1>
+    <span v-if="root.root" class="root-badge">{{ root.root }}</span>
   </header>
 
   <div id="page_content">

--- a/zygiskd/webui/src/components/StatusSection.vue
+++ b/zygiskd/webui/src/components/StatusSection.vue
@@ -2,15 +2,16 @@
 import { onMounted, onUnmounted, ref } from "vue";
 import { fetchState, parseMonitor } from "../api/system";
 import { useLocale } from "../composables/useLocale";
+import { useRoot } from "../composables/useRoot";
 import Card from "../components/atoms/Card.vue";
 import type { MonitorRow } from "../types";
 
 const { t } = useLocale();
+const { setRoot } = useRoot();
 
 const loading = ref(true);
 const error = ref<string | null>(null);
 const monitor = ref<MonitorRow[]>([]);
-const rootImpl = ref("");
 
 let timer: number | undefined;
 
@@ -24,7 +25,7 @@ function valClass(v: string): string {
 async function load() {
   try {
     const d = await fetchState();
-    rootImpl.value = d.keys.root || "";
+    setRoot(d.keys.root || "");
     monitor.value = parseMonitor(d.monitor);
     error.value = null;
   } catch (e) {
@@ -58,10 +59,6 @@ onUnmounted(() => window.clearInterval(timer));
       </div>
       <div v-else class="monitor-empty">{{ t("status.noStatus") }}</div>
     </Card>
-
-    <div v-if="rootImpl" class="root-label">
-      <span class="root-label__text">{{ rootImpl }}</span>
-    </div>
   </section>
 </template>
 
@@ -81,9 +78,4 @@ onUnmounted(() => window.clearInterval(timer));
   color: var(--text2); word-break: break-all;
 }
 .monitor-empty { color: var(--text3); font-size: 13px; padding: 4px 0; }
-
-.root-label {
-  padding: 8px 0 0; font-size: 12px;
-}
-.root-label__text { font-weight: 600; color: var(--text3); }
 </style>

--- a/zygiskd/webui/src/composables/useRoot.ts
+++ b/zygiskd/webui/src/composables/useRoot.ts
@@ -1,0 +1,13 @@
+/* OnyxZygisk — shared root-implementation label.
+ * A tiny reactive singleton: the status section sets `root` on every poll,
+ * and the header (App.vue) renders it in the top-right corner. */
+import { reactive } from "vue";
+
+const state = reactive<{ root: string }>({ root: "" });
+
+export function useRoot() {
+  function setRoot(v: string): void {
+    state.root = v;
+  }
+  return { root: state, setRoot };
+}

--- a/zygiskd/webui/src/styles/main.css
+++ b/zygiskd/webui/src/styles/main.css
@@ -61,6 +61,14 @@ a { color: var(--primary); text-decoration: none; }
 .header-icon img { width: 36px; height: 36px; object-fit: contain; display: block; }
 .header-title { font-size: 17px; font-weight: 600; letter-spacing: -.2px; }
 
+/* root implementation label (top-right of the header) */
+.root-badge {
+  margin-left: auto; white-space: nowrap;
+  font-size: 11px; font-weight: 500; color: var(--text2);
+  padding: 3px 10px; background: var(--surface2);
+  border: 1px solid var(--border-strong); border-radius: 99px;
+}
+
 /* ── page container (single fixed page) ── */
 #page_content { max-width: 720px; margin: 0 auto; padding: 6px 20px 20px; animation: fade .2s ease; }
 @keyframes fade { from { opacity: 0; } to { opacity: 1; } }


### PR DESCRIPTION
把 Root 方案标签（KernelSU/APatch/FolkPatch/Magisk）从监控器卡片下方移到顶栏右上角。

- 新增极简共享状态 composable `useRoot`（状态页轮询写入，顶栏读取）
- 顶栏右侧柔和胶囊样式（1px 描边 + 全圆角），与图标垂直居中
- 移除监控器卡片下方的旧标签

（按新准则：分支提交 + PR 合入，替换原直接推送的 7002a42）