### PR TITLE
fix(webui): detect root provider by running daemon, not stale files

### DIFF
--- a/zygiskd/webui/src/api/system.ts
+++ b/zygiskd/webui/src/api/system.ts
@@ -9,14 +9,17 @@ const STATUS_SCRIPT = [
   'MOD="' + MODDIR + '"; W="' + WORKDIR + '"',
   'v=$(sed -n "s/^version=//p" "$MOD/module.prop" 2>/dev/null | head -n1)',
   "r=none",
-  // Root detection order matters: later matches override earlier ones.
-  // FolkPatch (an APatch extended branch) ships its own daemon under
-  // /data/adb/fp while keeping the APatch-compatible `apd`, so it is checked
-  // after APatch and wins when both are present.
-  "[ -x /data/adb/ap/bin/apd ] && r=APatch",
-  "[ -x /data/adb/fp/bin/fpd ] && r=FolkPatch",
+  // Root provider detection: only a RUNNING daemon counts. Stale files from a
+  // previous setup (leftover `apd` on a KernelSU device) or a magisk-compatible
+  // binary in PATH on APatch/KernelSU devices must not win, so there are no
+  // file/PATH fallbacks. FolkPatch keeps APatch's `apd` next to its own `fpd`,
+  // so fpd wins when both daemons run.
+  "pidof apd >/dev/null 2>&1 && r=APatch",
+  "pidof fpd >/dev/null 2>&1 && r=FolkPatch",
   "[ -d /data/adb/ksu ] && r=KernelSU",
-  "command -v magisk >/dev/null 2>&1 && r=Magisk",
+  "pidof magiskd >/dev/null 2>&1 && r=Magisk",
+  // Print an empty label instead of "none" when nothing was detected.
+  '[ "$r" = none ] && r=',
   'echo "version=$v"; echo "root=$r"',
   'pidof zygote64 >/dev/null 2>&1 && echo "z64=1" || echo "z64=0"',
   '(pidof zygote >/dev/null 2>&1 || pidof zygote_secondary >/dev/null 2>&1) && echo "z32=1" || echo "z32=0"',


### PR DESCRIPTION
顶栏绿色 Root 方案标签识别错误的修复。

## 问题
- KernelSU 设备上残留上一次 APatch 安装的 `apd` 二进制（未运行）→ 误显示 APatch
- APatch/KernelSU 设备 PATH 里有 magisk 兼容二进制 → 误显示 Magisk（`command -v magisk` 是最后一条，会覆盖前面所有结果）

## 修复
只信任**正在运行的守护进程**：
- `pidof apd` → APatch
- `pidof fpd` → FolkPatch（与 apd 同时运行时 fpd 胜出，FolkPatch 保留 apd 兼容）
- `/data/adb/ksu` 目录 → KernelSU
- `pidof magiskd` → Magisk（只有真 Magisk 才跑 magiskd）

移除了会产生误判的文件/PATH 兜底检查；未检测到时显示空标签而非 `none`。

## 验证
WSL 模拟 7 种设备状态全部识别正确（含两个原误判场景）；vitest 46/46 通过。