### PR TITLE
chore(module): keep module.prop lines clean and regular

### DIFF
--- a/module/build.gradle.kts
+++ b/module/build.gradle.kts
@@ -113,7 +113,9 @@ androidComponents.onVariants { variant ->
             expand(
                 "moduleId" to moduleId,
                 "moduleName" to moduleName,
-                "versionName" to "$verName ($verCode-$commitHash-$variantLowered)",
+                // Keep the version line clean — build metadata stays in the
+                // zip file name only (OnyxZygisk-v1.0.5-329-<hash>-release.zip).
+                "versionName" to verName,
                 "versionCode" to verCode
             )
         }

--- a/module/src/module.prop
+++ b/module/src/module.prop
@@ -3,4 +3,4 @@ name=${moduleName}
 version=${versionName}
 versionCode=${versionCode}
 author=Sai, Matsuzaka Yuki
-description= OnyxZygisk · Zygote injection via ptrace, with FN (Functional Node) modules and a built-in WebUI.
+description=Zygote injection via ptrace, with FN (Functional Node) modules and a built-in WebUI.


### PR DESCRIPTION
规整 module.prop 的每一行。

- `version` 行去掉 `(329-<hash>-release)` 构建尾巴，只保留 `v1.0.5`（构建信息在 zip 文件名里）
- `description` 去掉 `=` 后的前导空格和 `·` 分隔符

每行都是规整的 `key=value`。