### PR TITLE
fix(monitor): tidy monitor output — drop description, sort rows short-to-long

### DIFF
--- a/loader/src/ptracer/monitor.hpp
+++ b/loader/src/ptracer/monitor.hpp
@@ -181,5 +181,4 @@ private:
     std::string monitor_stop_reason_;
     std::string prop_path_;
     std::string pre_section_;
-    std::string post_section_;
 };

--- a/loader/src/ptracer/monitor_impl.cpp
+++ b/loader/src/ptracer/monitor_impl.cpp
@@ -102,7 +102,7 @@ void AppMonitor::update_status() {
     std::string abi_section;
     write_abi_status_section(abi_section, zygote_.get_status());
 
-    ss << abi_section << "\n\n" << post_section_;
+    ss << abi_section << "\n\n";
 
     std::string final_output = ss.str();
     fwrite(final_output.c_str(), 1, final_output.length(), prop_file.get());
@@ -116,17 +116,13 @@ bool AppMonitor::prepare_environment() {
         PLOGE("open original prop");
         return false;
     }
-    bool post = false;
     file_readline(false, orig_prop.get(), [&](std::string_view line) -> bool {
         if (line.starts_with("updateJson=")) return true;
-        if (line.starts_with("description=")) {
-            post = true;
-            // Keep the "description=" key so the generated prop stays valid.
-            post_section_ += line.substr(sizeof("description") - 1);
-        } else {
-            (post ? post_section_ : pre_section_) += "\t";
-            (post ? post_section_ : pre_section_) += line;
-        }
+        // The description belongs in the installed module.prop only — this
+        // file is a live status file, so it is skipped here like updateJson.
+        if (line.starts_with("description=")) return true;
+        pre_section_ += "\t";
+        pre_section_ += line;
         return true;
     });
     update_status();

--- a/module/src/action.sh
+++ b/module/src/action.sh
@@ -15,7 +15,7 @@ else
   grep -E '^[[:blank:]]*[a-zA-Z][a-zA-Z0-9_]*=' "$PROP" | sed -E 's/^[[:blank:]]+//'
   echo
   echo "Monitor:"
-  grep -Ev '^[[:blank:]]*[a-zA-Z][a-zA-Z0-9_]*=' "$PROP" | grep -v '^[[:blank:]]*$' | sed -E 's/^[[:blank:]]+//; s/:[[:blank:]]+/: /'
+  grep -Ev '^[[:blank:]]*[a-zA-Z][a-zA-Z0-9_]*=|^[[:blank:]]*=' "$PROP" | grep -v '^[[:blank:]]*$' | sed -E 's/^[[:blank:]]+//; s/:[[:blank:]]+/: /' | awk '{ print length($0), $0 }' | sort -n | cut -d' ' -f2-
 fi
 
 echo

--- a/zygiskd/webui/src/api/system.ts
+++ b/zygiskd/webui/src/api/system.ts
@@ -123,7 +123,9 @@ export function parseMonitor(text: string): MonitorRow[] {
   for (const raw of String(text || "").split("\n")) {
     const s = raw.replace(/^\t+/, "").trim();
     if (!s) continue;
-    if (/^[a-zA-Z][a-zA-Z0-9_]*=/.test(s)) continue; // module metadata
+    // Module metadata ("key=value") and stray "=..." remnants from older
+    // monitor builds are not status rows.
+    if (/^[a-zA-Z][a-zA-Z0-9_]*=/.test(s) || s.startsWith("=")) continue;
     const m = /^([a-z][a-z0-9]*):\s*(.+)$/.exec(s);
     rows.push(m ? { label: m[1], value: m[2] } : { label: null, value: s });
   }

--- a/zygiskd/webui/src/components/StatusSection.test.ts
+++ b/zygiskd/webui/src/components/StatusSection.test.ts
@@ -38,6 +38,19 @@ describe("StatusSection", () => {
     wrapper.unmount();
   });
 
+  it("renders monitor rows from the shortest line to the longest", async () => {
+    const wrapper = mount(StatusSection);
+    await flushPromises();
+    // "Root: APatch" (12) sorts before "monitor: tracing" (16) and
+    // "zygote64: injected" (19).
+    const kids = wrapper.findAll(".monitor-list > div");
+    expect(kids[0].find(".monitor-detail").exists()).toBe(true);
+    expect(kids[0].text()).toBe("Root: APatch");
+    expect(kids[1].find(".m-label").text()).toBe("monitor");
+    expect(kids[2].find(".m-label").text()).toBe("zygote64");
+    wrapper.unmount();
+  });
+
   it("colors healthy monitor values with the ok class", async () => {
     const wrapper = mount(StatusSection);
     await flushPromises();

--- a/zygiskd/webui/src/components/StatusSection.vue
+++ b/zygiskd/webui/src/components/StatusSection.vue
@@ -3,10 +3,11 @@
  * in App.vue) comes from the shared MONITOR_STATE_KEY instance; when mounted
  * standalone (unit tests) a local instance is created instead.
  */
-import { inject } from "vue";
+import { computed, inject } from "vue";
 import { useLocale } from "../composables/useLocale";
 import { MONITOR_STATE_KEY, useMonitorState } from "../composables/useMonitorState";
 import type { MonitorState } from "../composables/useMonitorState";
+import type { MonitorRow } from "../types";
 import Card from "./atoms/Card.vue";
 
 const { t } = useLocale();
@@ -20,6 +21,16 @@ function valClass(v: string): string {
   if (/unknown/i.test(v)) return "warn";
   return "";
 }
+
+/** Display length of a row ("label: value" for labeled rows). */
+function rowLen(r: MonitorRow): number {
+  return r.label ? r.label.length + 2 + r.value.length : r.value.length;
+}
+
+/** Monitor rows render from the shortest line to the longest. */
+const sortedMonitor = computed(() =>
+  [...monitor.value].sort((a, b) => rowLen(a) - rowLen(b)),
+);
 </script>
 
 <template>
@@ -28,7 +39,7 @@ function valClass(v: string): string {
       <div v-if="loading" class="monitor-empty">{{ t("common.loading") }}</div>
       <div v-else-if="error" class="monitor-empty">{{ t("common.error") }}: {{ error }}</div>
       <div v-else-if="monitor.length" class="monitor-list">
-        <div v-for="(r, i) in monitor" :key="i">
+        <div v-for="(r, i) in sortedMonitor" :key="i">
           <div v-if="r.label" class="monitor-row">
             <div class="m-label">{{ r.label }}</div>
             <div class="m-val" :class="valClass(r.value)">{{ r.value }}</div>


### PR DESCRIPTION
监控器输出规整：

- workdir module.prop 不再追加模块 description（它只属于已安装的 module.prop），消除监控卡片里 `=Zygote injection...` 残留行（C++ 侧 post_section 逻辑移除）
- 监控器行按整行长度从短到长排序（WebUI 卡片 + action.sh Monitor 段）
- parseMonitor / action.sh 防御性过滤旧版本残留的 `=...` 行

验证：vitest 47/47（新增排序测试）；action.sh 排序 WSL 实测；完整构建通过。