### PR TITLE
fix(webui): keep hero collapse transition, drop backdrop-filter jank

### DIFF
--- a/zygiskd/webui/src/App.vue
+++ b/zygiskd/webui/src/App.vue
@@ -109,9 +109,11 @@ onUnmounted(() => {
   border-radius: var(--radius);
   box-shadow: var(--shadow-hero);
   padding: 20px;
-  /* No transitions on the compact toggle: animating padding/border-radius/
-   * box-shadow re-layouts and repaints the sticky hero every frame while
-   * scrolling, which stutters. The collapse is instant instead. */
+  transition:
+    padding 0.25s ease,
+    border-radius 0.25s ease,
+    background-color 0.25s ease,
+    box-shadow 0.25s ease;
 }
 /* Brand accent line along the bottom edge of the expanded hero. */
 .hero::after {
@@ -133,9 +135,10 @@ onUnmounted(() => {
   border-right: none;
   border-top: none;
   background: var(--header-bg);
-  -webkit-backdrop-filter: blur(18px) saturate(1.6);
-  backdrop-filter: blur(18px) saturate(1.6);
   box-shadow: none;
+  /* No backdrop-filter here: enabling a blur mid-scroll forces the WebView
+   * to re-render the blurred region on every animation frame and stutters
+   * badly on Android. The header background is opaque enough on its own. */
 }
 .hero--compact::after {
   display: none;
@@ -150,6 +153,10 @@ onUnmounted(() => {
   background:
     radial-gradient(120% 120% at 80% 20%, var(--primary-bg), transparent 55%),
     linear-gradient(135deg, var(--primary-bg), transparent 65%);
+  transition:
+    width 0.25s ease,
+    height 0.25s ease,
+    border-radius 0.25s ease;
 }
 .hero__glyph {
   display: block;
@@ -158,6 +165,9 @@ onUnmounted(() => {
   background-color: var(--primary);
   -webkit-mask: url("/icons/syringe.svg") center / contain no-repeat;
   mask: url("/icons/syringe.svg") center / contain no-repeat;
+  transition:
+    width 0.25s ease,
+    height 0.25s ease;
 }
 .hero--compact .hero__icon {
   width: 36px;

--- a/zygiskd/webui/src/styles/main.css
+++ b/zygiskd/webui/src/styles/main.css
@@ -27,7 +27,7 @@
   --orange-bg: rgba(240, 160, 32, 0.14);
   --shadow-card: 0 1px 2px rgba(16, 24, 40, 0.04), 0 1px 3px rgba(16, 24, 40, 0.06);
   --shadow-hero: 0 2px 6px rgba(24, 160, 88, 0.08), 0 1px 3px rgba(16, 24, 40, 0.05);
-  --header-bg: rgba(242, 243, 245, 0.82);
+  --header-bg: rgba(242, 243, 245, 0.92);
 }
 [data-theme="dark"] {
   --bg: #0f1013;
@@ -51,7 +51,7 @@
   --orange-bg: rgba(242, 201, 125, 0.13);
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3), 0 2px 6px rgba(0, 0, 0, 0.2);
   --shadow-hero: 0 2px 8px rgba(99, 226, 183, 0.07), 0 1px 3px rgba(0, 0, 0, 0.3);
-  --header-bg: rgba(15, 16, 19, 0.82);
+  --header-bg: rgba(15, 16, 19, 0.92);
 }
 [data-theme="amoled"] {
   --bg: #000000;
@@ -75,7 +75,7 @@
   --orange-bg: rgba(242, 201, 125, 0.13);
   --shadow-card: none;
   --shadow-hero: none;
-  --header-bg: rgba(0, 0, 0, 0.82);
+  --header-bg: rgba(0, 0, 0, 0.92);
 }
 
 :root {


### PR DESCRIPTION
保留 transition 的丝滑动画，同时消除滚动卡顿。

- 恢复 hero 的 padding/border-radius/box-shadow/background-color 和图标尺寸的 transition（0.25s ease）
- 移除 compact 状态的 backdrop-filter blur(18px) —— 这是 Android WebView 卡顿的真正元凶：滚动中启用背景模糊会让 WebView 每帧重算模糊区域（配合 padding 动画更是雪上加霜）
- 顶栏底色不透明度 0.82 → 0.92，无模糊也不透字
- 保留 requestAnimationFrame 节流

验证：vitest 47/47；浏览器计算样式确认 transition 恢复、backdrop-filter 为 none。