### PR TITLE
fix(webui): stop the hero bar twitching, keep the collapse animation

### DIFF
--- a/zygiskd/webui/src/App.test.ts
+++ b/zygiskd/webui/src/App.test.ts
@@ -29,6 +29,15 @@ const stubs = {
   SettingsSection: true,
 };
 
+/** jsdom does not implement a settable scrollY, so stub the getter and let the
+ *  rAF-throttled scroll handler run one frame. */
+async function scrollTo(y: number): Promise<void> {
+  Object.defineProperty(window, "scrollY", { value: y, configurable: true });
+  window.dispatchEvent(new Event("scroll"));
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  await Promise.resolve();
+}
+
 beforeEach(() => {
   vi.mocked(fetchState).mockResolvedValue(state());
 });
@@ -42,6 +51,7 @@ describe("App hero", () => {
     expect(hero.find(".root-label__text").text()).toBe("APatch");
     expect(hero.text()).toContain("v1.0");
     expect(hero.find(".badge").text()).toContain("Working");
+    expect(hero.find(".hero__extra").attributes("aria-hidden")).toBeUndefined();
     wrapper.unmount();
   });
 
@@ -50,17 +60,42 @@ describe("App hero", () => {
     await flushPromises();
     expect(wrapper.find(".hero--compact").exists()).toBe(false);
 
-    // jsdom does not implement a settable scrollY: stub the getter.
-    Object.defineProperty(window, "scrollY", { value: 100, configurable: true });
-    window.dispatchEvent(new Event("scroll"));
-    // The scroll handler is rAF-throttled: wait one animation frame.
-    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-    await Promise.resolve();
+    await scrollTo(100);
 
     expect(wrapper.find(".hero--compact").exists()).toBe(true);
-    expect(wrapper.find(".hero__sub").exists()).toBe(false);
-    expect(wrapper.find(".hero__chips").exists()).toBe(false);
+    // The subtitle and chips stay mounted and are collapsed by CSS, so that the
+    // bar animates shut as one piece; only their aria state changes here.
+    expect(wrapper.find(".hero__extra").attributes("aria-hidden")).toBe("true");
     wrapper.unmount();
-    Object.defineProperty(window, "scrollY", { value: 0, configurable: true });
+    await scrollTo(0);
+  });
+
+  it("stays compact until the very top, so a scrollY clamp cannot flip it back", async () => {
+    const wrapper = mount(App, { global: { stubs } });
+    await flushPromises();
+    await scrollTo(100);
+    expect(wrapper.find(".hero--compact").exists()).toBe(true);
+
+    // A shorter document clamps scrollY downwards. Anything above the top must
+    // leave the bar compact, otherwise the collapse and the clamp oscillate.
+    await scrollTo(20);
+    expect(wrapper.find(".hero--compact").exists()).toBe(true);
+    await scrollTo(1);
+    expect(wrapper.find(".hero--compact").exists()).toBe(true);
+
+    await scrollTo(0);
+    expect(wrapper.find(".hero--compact").exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it("reserves the expanded hero height in the flow", async () => {
+    const wrapper = mount(App, { global: { stubs } });
+    await flushPromises();
+    // The spacer is what keeps the document height constant across the
+    // collapse; it must be rendered and sized from the hero, not left at auto.
+    const spacer = wrapper.find(".hero-spacer");
+    expect(spacer.exists()).toBe(true);
+    expect(spacer.attributes("style")).toContain("height");
+    wrapper.unmount();
   });
 });

--- a/zygiskd/webui/src/App.vue
+++ b/zygiskd/webui/src/App.vue
@@ -3,7 +3,7 @@
  * scrolling and collapses into a compact bar (small icon, chips hidden).
  * System state is shared with StatusSection via MONITOR_STATE_KEY.
  */
-import { computed, onMounted, onUnmounted, provide, ref } from "vue";
+import { computed, onMounted, onUnmounted, provide, ref, watch } from "vue";
 import { fmtVer } from "./api/system";
 import { MONITOR_STATE_KEY, useMonitorState } from "./composables/useMonitorState";
 import { useLocale } from "./composables/useLocale";
@@ -40,40 +40,87 @@ const overall = computed(() => {
 });
 
 const compact = ref(false);
+const heroEl = ref<HTMLElement | null>(null);
+/** Expanded hero height, held in the flow by the spacer (see the style block). */
+const heroHeight = ref(0);
+
+/** Collapse animation length; keep in sync with the transitions in the style block. */
+const COLLAPSE_MS = 250;
+let settling: number | undefined;
+let animating = false;
+
+function measure(): void {
+  // Only the settled, expanded height is ever recorded. Tracking the compact
+  // bar would shorten the document by ~60px the moment the hero collapsed —
+  // the twitch this component kept regressing into, see onScroll. Mid-animation
+  // frames are skipped too, otherwise the spacer would follow the hero down and
+  // back up while it expands and drag the page content with it.
+  if (compact.value || animating || !heroEl.value) return;
+  heroHeight.value = heroEl.value.offsetHeight;
+}
+
+watch(compact, () => {
+  animating = true;
+  clearTimeout(settling);
+  settling = window.setTimeout(() => {
+    animating = false;
+    measure();
+  }, COLLAPSE_MS + 50);
+});
+
 // Coalesce scroll events into a single class update per animation frame.
-// The toggle itself is cheap; this keeps it from flipping mid-frame while
-// the user is scrolling.
 let rafId = 0;
 function onScroll(): void {
   if (rafId) return;
   rafId = requestAnimationFrame(() => {
     rafId = 0;
-    compact.value = window.scrollY > 16;
+    const y = window.scrollY;
+    // Asymmetric thresholds. A single threshold flips on every pixel of scroll
+    // jitter around it, and the browser clamping scrollY after a layout change
+    // used to push the state straight back across it — the two fed each other
+    // and the bar convulsed. Collapsing needs real downward scroll; expanding
+    // only happens back at the very top, which no clamp can overshoot into.
+    if (compact.value ? y <= 0 : y > 24) compact.value = !compact.value;
   });
 }
+
+let ro: ResizeObserver | undefined;
 onMounted(() => {
+  measure();
+  // Re-measure when the hero's content changes height (chips arriving after the
+  // first fetch, a locale switch, a viewport resize rewrapping the subtitle).
+  if (heroEl.value && typeof ResizeObserver !== "undefined") {
+    ro = new ResizeObserver(measure);
+    ro.observe(heroEl.value);
+  }
   window.addEventListener("scroll", onScroll, { passive: true });
   onScroll();
 });
 onUnmounted(() => {
   window.removeEventListener("scroll", onScroll);
+  ro?.disconnect();
+  clearTimeout(settling);
   if (rafId) cancelAnimationFrame(rafId);
 });
 </script>
 
 <template>
-  <header class="hero" :class="{ 'hero--compact': compact }">
+  <header ref="heroEl" class="hero" :class="{ 'hero--compact': compact }">
     <div class="hero__icon" aria-hidden="true">
       <span class="hero__glyph"></span>
     </div>
     <div class="hero__body">
       <div class="hero__title">OnyxZygisk</div>
-      <div v-if="!compact" class="hero__sub">{{ t("header.subtitle") }}</div>
-      <div v-if="!compact" class="hero__chips">
-        <span v-if="rootImpl" class="chip chip--accent root-label">
-          <span class="root-label__text">{{ rootImpl }}</span>
-        </span>
-        <span v-if="version" class="chip">{{ fmtVer(version) }}</span>
+      <!-- Kept mounted and collapsed by CSS: removing it with v-if would drop
+           ~40px of the hero instantly and the padding would animate alone. -->
+      <div class="hero__extra" :aria-hidden="compact || undefined">
+        <div class="hero__sub">{{ t("header.subtitle") }}</div>
+        <div class="hero__chips">
+          <span v-if="rootImpl" class="chip chip--accent root-label">
+            <span class="root-label__text">{{ rootImpl }}</span>
+          </span>
+          <span v-if="version" class="chip">{{ fmtVer(version) }}</span>
+        </div>
       </div>
     </div>
     <span class="badge" :class="overall.cls">
@@ -82,6 +129,7 @@ onUnmounted(() => {
       {{ t(overall.key) }}
     </span>
   </header>
+  <div class="hero-spacer" :style="{ height: heroHeight + 'px' }"></div>
 
   <div id="page_content">
     <StatusSection />
@@ -93,10 +141,18 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
-/* ── status hero: page header, sticks to the top, collapses on scroll ── */
+/* ── status hero: page header, pinned to the top, collapses on scroll ──
+ * Fixed rather than sticky, with .hero-spacer holding its expanded height in
+ * the flow. A sticky hero is part of the document, so collapsing it shortened
+ * the page mid-scroll: content jerked upwards under the finger and the
+ * resulting scrollY clamp re-entered the scroll handler. Fixed + spacer keeps
+ * the document height constant no matter which state the bar is in.
+ */
 .hero {
-  position: sticky;
+  position: fixed;
   top: 0;
+  left: 0;
+  right: 0;
   z-index: 50;
   max-width: 720px;
   margin: 0 auto;
@@ -108,12 +164,18 @@ onUnmounted(() => {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow-hero);
-  padding: 20px;
+  padding: calc(20px + env(safe-area-inset-top, 0px)) 20px 20px;
+  /* Animating padding / radius / size is only affordable because the hero is
+   * out of flow: the reflow each frame is scoped to this header's handful of
+   * nodes instead of the whole document. */
   transition:
     padding 0.25s ease,
     border-radius 0.25s ease,
     background-color 0.25s ease,
     box-shadow 0.25s ease;
+}
+.hero-spacer {
+  width: 100%;
 }
 /* Brand accent line along the bottom edge of the expanded hero. */
 .hero::after {
@@ -168,6 +230,19 @@ onUnmounted(() => {
   transition:
     width 0.25s ease,
     height 0.25s ease;
+}
+/* Subtitle + chips: collapse together with the bar instead of disappearing. */
+.hero__extra {
+  overflow: hidden;
+  max-height: 64px;
+  opacity: 1;
+  transition:
+    max-height 0.25s ease,
+    opacity 0.16s ease;
+}
+.hero--compact .hero__extra {
+  max-height: 0;
+  opacity: 0;
 }
 .hero--compact .hero__icon {
   width: 36px;

--- a/zygiskd/webui/src/styles/main.css
+++ b/zygiskd/webui/src/styles/main.css
@@ -27,7 +27,9 @@
   --orange-bg: rgba(240, 160, 32, 0.14);
   --shadow-card: 0 1px 2px rgba(16, 24, 40, 0.04), 0 1px 3px rgba(16, 24, 40, 0.06);
   --shadow-hero: 0 2px 6px rgba(24, 160, 88, 0.08), 0 1px 3px rgba(16, 24, 40, 0.05);
-  --header-bg: rgba(242, 243, 245, 0.92);
+  /* Opaque: the compact header has no backdrop-filter behind it, so any alpha
+   * here just lets the scrolling content ghost through the bar. */
+  --header-bg: #f2f3f5;
 }
 [data-theme="dark"] {
   --bg: #0f1013;
@@ -51,7 +53,7 @@
   --orange-bg: rgba(242, 201, 125, 0.13);
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3), 0 2px 6px rgba(0, 0, 0, 0.2);
   --shadow-hero: 0 2px 8px rgba(99, 226, 183, 0.07), 0 1px 3px rgba(0, 0, 0, 0.3);
-  --header-bg: rgba(15, 16, 19, 0.92);
+  --header-bg: #0f1013;
 }
 [data-theme="amoled"] {
   --bg: #000000;
@@ -75,7 +77,7 @@
   --orange-bg: rgba(242, 201, 125, 0.13);
   --shadow-card: none;
   --shadow-hero: none;
-  --header-bg: rgba(0, 0, 0, 0.92);
+  --header-bg: #000000;
 }
 
 :root {


### PR DESCRIPTION
The sticky hero was part of the document flow, so collapsing it took ~66px out of the page mid-scroll. Content jerked upwards under the finger, and on a barely-scrollable page the browser clamped `scrollY` back below the 16px threshold, which re-expanded the bar, which lengthened the page again — the scroll handler and the layout drove each other and the bar convulsed.

#13 and #14 both went after the animation for this. The animation was never the cause; being in the flow was.

## Changes

- The hero is `position: fixed`, with a `.hero-spacer` holding its expanded height in the flow, so the **document height is identical in both states**.
- Collapse/expand thresholds are asymmetric — collapse past 24px, expand only back at the very top — so no clamp or scroll jitter can flip it back.
- The spacer records the hero only while expanded *and settled*, never a mid-animation frame, so expanding cannot drag the page content with it.
- **The collapse animation is kept.** Out of flow, the per-frame reflow is scoped to the header's own nodes instead of the whole document. The subtitle and chips are collapsed by CSS rather than removed with `v-if`, so the bar animates shut as one piece instead of losing 40px instantly while the padding eased.
- `--header-bg` is opaque now. With the backdrop-filter gone (#14) its `0.92` alpha only let scrolling content ghost through the bar.
- The expanded hero honours `safe-area-inset-top` too, not just the compact one.

## Verification

Measured in the dev preview at a 375px viewport, sampling every animation frame:

| | collapse | expand |
|---|---|---|
| hero height | 123 → 60px over 23 frames | 57 → 122px over 27 frames |
| document height | constant | constant |
| spacer height | constant | constant |
| `#page_content` top | — | constant at 123px |

- Sweeping scrollY back and forth across the old threshold band produces exactly one class flip per deliberate crossing — no oscillation.
- With the page shrunk to a 30px scroll range (the worst case, where the collapse used to remove more height than the whole scrollable range) the bar settles after a single flip.
- 49/49 tests pass, `vue-tsc --noEmit` clean. New coverage for the hysteresis and for the spacer.
