### PR TITLE
feat(loader): module-loading seam for an in-process custom linker (stage 1)

### DIFF
--- a/docs/CUSTOM_LINKER.md
+++ b/docs/CUSTOM_LINKER.md
@@ -1,0 +1,104 @@
+# In-process custom module loader
+
+## Goal
+
+Load Zygisk / FN module libraries into the target process **without registering
+them in the system linker's `solist`**, so linker-walk detection (an app
+iterating loaded `soinfo` records, or reading `/proc/self/maps` for a
+recognisable library path) finds nothing to flag.
+
+Today OnyxZygisk is **reactive**: the system linker loads the module via
+`android_dlopen_ext` (`common/dl.cpp:DlopenMem`), the module briefly appears in
+`solist`, and `injector/solist.cpp:dropSoPath` unlinks it afterwards. The custom
+loader is **proactive**: the module is mapped, relocated and initialised by our
+own code and never enters `solist` in the first place.
+
+This is the same technique ReZygisk markets under "custom linker (CSOLoader)".
+The *idea* is shared; the *code* here is not — see Licensing.
+
+## Licensing (hard constraint)
+
+- OnyxZygisk is **GPL-3.0** (inherited from NeoZygisk, upstream GPL-3.0).
+- ReZygisk's `CSOLoader` (github.com/ThePedroo/CSOLoader) is **AGPL-3.0**.
+
+AGPL-3.0 source must not be copied or adapted into this project: doing so would
+force AGPL obligations onto the whole work (GPLv3 §13 permits the combination,
+but that is a deliberate relicensing the project has chosen **not** to make).
+"Read it and write a similar one" is not a loophole — access plus substantial
+similarity makes a derivative work regardless of rewording.
+
+Therefore the loader here is written **only** from:
+
+- the public **ELF** and **AArch64 / ARM ELF ABI** specifications;
+- Android's **bionic** linker, which is **Apache-2.0** (GPL-compatible), used as
+  a reference for Android-specific behaviour;
+- this repository's own GPL-3.0 code (`injector/solist.cpp`,
+  `include/elf_parser.hpp`, `include/linker_soinfo.h`).
+
+No CSOLoader / ReZygisk source is consulted while implementing it.
+
+## The seam
+
+Both module load sites in `injector/module.cpp` (classic modules in
+`run_modules_pre`, and FN nodes right after) go through one function:
+
+```
+LoadedModule LoadModuleFromMemfd(int memfd);   // include/module_loader.hpp
+```
+
+`LoadedModule` carries `{ handle, entry, custom }`. Callers only check
+`operator bool` (did `zygisk_module_entry` resolve?) and read `handle` / `entry`.
+This decouples the call sites from *how* the library was loaded.
+
+## Stages
+
+**Stage 1 — the seam (done).**
+`LoadModuleFromMemfd` wraps the previous `DlopenMem` + `dlsym` exactly;
+`custom` is always `false`. No behavioural change. Both call sites converted.
+Purpose: a single, testable place to add the custom path with a guaranteed
+fallback.
+
+**Stage 2 — read-only ELF loader, dry run.**
+Parse the module image from the memfd (program headers, dynamic section,
+relocation and symbol tables) and log what a load *would* do — segment layout,
+`DT_NEEDED` list, relocation counts — but still hand the process off to
+`DlopenMem`. Lets us validate the parser against real modules on-device with
+zero risk to boot.
+
+**Stage 3 — map + relocate + init, behind a flag.**
+Actually `mmap` the `PT_LOAD` segments, apply relocations
+(`R_AARCH64_RELATIVE`, `R_AARCH64_GLOB_DAT`, `R_AARCH64_JUMP_SLOT`,
+`R_AARCH64_ABS64`; ARM equivalents for 32-bit), resolve imports against
+already-loaded libraries via the in-process linker's own lookup, run
+`DT_INIT` / `DT_INIT_ARRAY`, and return a handle whose `dlsym` equivalent finds
+`zygisk_module_entry`. Gated by a compile-time flag (default off) **and** an
+automatic fallback: any failure in the custom path returns to `DlopenMem`, so a
+bug degrades to today's working behaviour instead of failing specialization.
+
+**Stage 4 — make it the default, keep the fallback.**
+Flip the default once it has been proven on a range of devices / Android
+versions. `dropSoPath` stays as a belt-and-braces cleanup for the fallback path.
+
+## Risk & verification
+
+A wrong loader means **zygote cannot load the module → boot loop**. This class
+of bug is largely invisible to unit tests and emulators; it must be verified on
+real hardware. The staged design exists precisely so each step is either
+inert (Stages 1–2) or fallback-protected (Stages 3–4).
+
+Required on-device checks before advancing a stage:
+
+- device boots and specializes apps normally with the flag **off** (regression);
+- with the flag **on**, a known module (e.g. a simple Zygisk module) loads and
+  its `onLoad` runs;
+- `/proc/<app>/maps` no longer shows the module's real path;
+- an app that walks `solist` / dlopen records does not observe the module;
+- both 64-bit and 32-bit zygote paths, across at least two Android versions.
+
+## Files
+
+- `include/module_loader.hpp` — the seam interface.
+- `common/module_loader.cpp` — Stage 1 implementation (system-linker wrapper);
+  the custom loader lands here behind the fallback.
+- `common/dl.cpp` — `DlopenMem`, the system-linker path / fallback.
+- `injector/solist.cpp` — existing reactive `solist` cleanup, retained.

--- a/loader/src/common/module_loader.cpp
+++ b/loader/src/common/module_loader.cpp
@@ -1,0 +1,40 @@
+#include "module_loader.hpp"
+
+#include "dl.hpp"
+#include "logging.hpp"
+
+/*
+ * Stage 1: the seam only. This routes both module load sites through a single
+ * function while preserving the exact behaviour of the previous inline
+ * `DlopenMem(memfd, RTLD_NOW)` + `dlsym(handle, "zygisk_module_entry")` pair.
+ *
+ * Stage 2 will add the in-process custom loader here, tried first and falling
+ * back to this system-linker path on any failure, behind a build/runtime flag.
+ * Keeping the fallback is what makes the custom path safe to iterate on: a bug
+ * in it degrades to the working linker instead of failing to specialize the
+ * process.
+ */
+
+static constexpr const char *ENTRY_SYMBOL = "zygisk_module_entry";
+
+LoadedModule LoadModuleFromMemfd(int memfd) {
+    LoadedModule out;
+
+    void *handle = DlopenMem(memfd, RTLD_NOW);
+    if (!handle) {
+        // DlopenMem already logged the dlerror(); nothing usable to return.
+        return out;
+    }
+
+    void *entry = dlsym(handle, ENTRY_SYMBOL);
+    if (!entry) {
+        LOGW("module handle %p has no `%s` symbol", handle, ENTRY_SYMBOL);
+        // Leave handle set so a caller could still close it; entry stays null,
+        // so the module is treated as unusable (operator bool == false).
+    }
+
+    out.handle = handle;
+    out.entry = entry;
+    out.custom = false;
+    return out;
+}

--- a/loader/src/include/module_loader.hpp
+++ b/loader/src/include/module_loader.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+/*
+ * Module loading seam.
+ *
+ * All Zygisk / FN module libraries are brought into the target process through
+ * this one entry point. Today it wraps the system dynamic linker
+ * (android_dlopen_ext, via DlopenMem). It exists so that an in-process custom
+ * ELF loader — one that maps the module without registering it in the linker's
+ * solist — can be dropped in behind a single interface, with the system linker
+ * kept as an always-available fallback.
+ *
+ * See docs/CUSTOM_LINKER.md for the staged plan and the licensing constraint
+ * (the custom loader is written from the public ELF/AArch64 ABI and Android's
+ * Apache-2.0 bionic linker — it is NOT derived from any AGPL custom-linker
+ * source).
+ */
+
+#include <dlfcn.h>
+
+struct LoadedModule {
+    /// Opaque handle for symbol lookups and, eventually, unloading.
+    /// For the system-linker path this is the dlopen() handle.
+    void *handle = nullptr;
+    /// Resolved address of the module's `zygisk_module_entry` symbol, or null
+    /// if the library failed to load or does not export the entry point.
+    void *entry = nullptr;
+    /// True once the in-process custom linker (not the system linker) produced
+    /// this handle. Always false in the current stage.
+    bool custom = false;
+
+    /// A module is usable only if its entry point resolved.
+    explicit operator bool() const { return entry != nullptr; }
+};
+
+/**
+ * @brief Load a Zygisk/FN module library from a memfd and resolve its entry.
+ *
+ * @param memfd A file descriptor holding the shared library image.
+ * @return The handle + resolved `zygisk_module_entry`; falsy if either the
+ *         load or the symbol lookup failed.
+ */
+LoadedModule LoadModuleFromMemfd(int memfd);

--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -16,6 +16,7 @@
 #include "files.hpp"
 #include "logging.hpp"
 #include "misc.hpp"
+#include "module_loader.hpp"
 #include "zygisk.hpp"
 
 using namespace std;
@@ -333,9 +334,8 @@ void ZygiskContext::run_modules_pre() {
     auto size = ms.size();
     for (size_t i = 0; i < size; i++) {
         auto &m = ms[i];
-        if (void *handle = DlopenMem(m.memfd, RTLD_NOW);
-            void *entry = handle ? dlsym(handle, "zygisk_module_entry") : nullptr) {
-            modules.emplace_back(i, handle, entry);
+        if (LoadedModule lm = LoadModuleFromMemfd(m.memfd)) {
+            modules.emplace_back(i, lm.handle, lm.entry);
         }
     }
 
@@ -351,11 +351,10 @@ void ZygiskContext::run_modules_pre() {
         auto &fn = fns[i];
         if (!fn_applies(fn, is_server)) continue;
         if (!is_server && !fn_scope_matches(fn, process)) continue;
-        if (void *handle = DlopenMem(fn.memfd, RTLD_NOW);
-            void *entry = handle ? dlsym(handle, "zygisk_module_entry") : nullptr) {
+        if (LoadedModule lm = LoadModuleFromMemfd(fn.memfd)) {
             LOGI("loading FN module `%s` into %s (priority %u)", fn.id.c_str(),
                  is_server ? "system_server" : process ? process : "unknown", fn.priority);
-            modules.emplace_back(size + i, handle, entry);
+            modules.emplace_back(size + i, lm.handle, lm.entry);
         }
     }
 


### PR DESCRIPTION
Groundwork for a proactive, in-process custom ELF loader — the "custom linker" idea ReZygisk markets — done the way a bootloop-risk change should be: staged, always compilable, always fallback-safe.

## What this PR does (Stage 1 only)

Routes both module load sites in `injector/module.cpp` (classic Zygisk modules and FN nodes) through one function:

```cpp
LoadedModule LoadModuleFromMemfd(int memfd);   // include/module_loader.hpp
```

It wraps the previous `DlopenMem(memfd, RTLD_NOW)` + `dlsym(..., "zygisk_module_entry")` **exactly** — `custom` is always `false`, behaviour is identical. This is purely the seam the real loader will slot into, with the system linker kept as an automatic fallback.

Builds clean for all four ABIs (`:loader:assembleRelease`).

## Why a seam first

A wrong custom linker means zygote can't load the module → **boot loop**, and that's largely invisible to emulators/unit tests. So the loader lands incrementally behind this seam with a guaranteed fallback: any failure in the custom path returns to `DlopenMem`, degrading to today's working behaviour instead of failing specialization.

## Licensing — why we're writing our own, not porting CSOLoader

- OnyxZygisk: **GPL-3.0**
- ReZygisk's CSOLoader: **AGPL-3.0**

Copying/adapting the AGPL loader would force AGPL onto the whole project. So the custom loader is written **only** from the public ELF / AArch64 ABI specs, Android's Apache-2.0 **bionic** linker, and this repo's own GPL-3.0 code (`solist.cpp`, `elf_parser.hpp`). No CSOLoader source is consulted.

## Plan

Full staged plan, licensing rationale, and the on-device verification each stage needs are in **`docs/CUSTOM_LINKER.md`**. Stages 2–4 (ELF parse dry-run → map/relocate/init behind a flag → default) are follow-up PRs, each verified on real hardware.

No behavioural change ships in this PR.
