### PR TITLE
feat(loader): integrate CSOLoader as in-process custom module loader (AGPL relicense)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ zygiskd/webui/dist/
 # Agent / tooling scratch
 .zcode/
 gradle/gradle-daemon-jvm.properties
+.claude/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "loader/src/external/csoloader"]
+	path = loader/src/external/csoloader
+	url = https://github.com/ThePedroo/CSOLoader

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
@@ -7,17 +7,15 @@
 
                             Preamble
 
-  The GNU General Public License is a free, copyleft license for
-software and other kinds of works.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
   The licenses for most software and other practical works are designed
 to take away your freedom to share and change the works.  By contrast,
-the GNU General Public License is intended to guarantee your freedom to
+our General Public Licenses are intended to guarantee your freedom to
 share and change all versions of a program--to make sure it remains free
-software for all its users.  We, the Free Software Foundation, use the
-GNU General Public License for most of our software; it applies also to
-any other work released this way by its authors.  You can apply it to
-your programs, too.
+software for all its users.
 
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
@@ -26,44 +24,34 @@ them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
 free programs, and that you know you can do these things.
 
-  To protect your rights, we need to prevent others from denying you
-these rights or asking you to surrender the rights.  Therefore, you have
-certain responsibilities if you distribute copies of the software, or if
-you modify it: responsibilities to respect the freedom of others.
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-  For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must pass on to the recipients the same
-freedoms that you received.  You must make sure that they, too, receive
-or can get the source code.  And you must show them these terms so they
-know their rights.
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-  Developers that use the GNU GPL protect your rights with two steps:
-(1) assert copyright on the software, and (2) offer you this License
-giving you legal permission to copy, distribute and/or modify it.
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-  For the developers' and authors' protection, the GPL clearly explains
-that there is no warranty for this free software.  For both users' and
-authors' sake, the GPL requires that modified versions be marked as
-changed, so that their problems will not be attributed erroneously to
-authors of previous versions.
-
-  Some devices are designed to deny users access to install or run
-modified versions of the software inside them, although the manufacturer
-can do so.  This is fundamentally incompatible with the aim of
-protecting users' freedom to change the software.  The systematic
-pattern of such abuse occurs in the area of products for individuals to
-use, which is precisely where it is most unacceptable.  Therefore, we
-have designed this version of the GPL to prohibit the practice for those
-products.  If such problems arise substantially in other domains, we
-stand ready to extend this provision to those domains in future versions
-of the GPL, as needed to protect the freedom of users.
-
-  Finally, every program is threatened constantly by software patents.
-States should not allow patents to restrict development and use of
-software on general-purpose computers, but in those that do, we wish to
-avoid the special danger that patents applied to a free program could
-make it effectively proprietary.  To prevent this, the GPL assures that
-patents cannot be used to render the program non-free.
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
@@ -72,7 +60,7 @@ modification follow.
 
   0. Definitions.
 
-  "This License" refers to version 3 of the GNU General Public License.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
   "Copyright" also means copyright-like laws that apply to other kinds of
 works, such as semiconductor masks.
@@ -549,35 +537,45 @@ to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
 License would be to refrain entirely from conveying the Program.
 
-  13. Use with the GNU Affero General Public License.
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
 
   Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
-under version 3 of the GNU Affero General Public License into a single
+under version 3 of the GNU General Public License into a single
 combined work, and to convey the resulting work.  The terms of this
 License will continue to apply to the part which is the covered work,
-but the special requirements of the GNU Affero General Public License,
-section 13, concerning interaction through a network will apply to the
-combination as such.
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
 
   14. Revised Versions of this License.
 
   The Free Software Foundation may publish revised and/or new versions of
-the GNU General Public License from time to time.  Such new versions will
-be similar in spirit to the present version, but may differ in detail to
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
   Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU General
+Program specifies that a certain numbered version of the GNU Affero General
 Public License "or any later version" applies to it, you have the
 option of following the terms and conditions either of that numbered
 version or of any later version published by the Free Software
 Foundation.  If the Program does not specify a version number of the
-GNU General Public License, you may choose any version ever published
+GNU Affero General Public License, you may choose any version ever published
 by the Free Software Foundation.
 
   If the Program specifies that a proxy can decide which future
-versions of the GNU General Public License can be used, that proxy's
+versions of the GNU Affero General Public License can be used, that proxy's
 public statement of acceptance of a version permanently authorizes you
 to choose that version for the Program.
 
@@ -635,40 +633,29 @@ the "copyright" line and a pointer to where the full notice is found.
     Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+    GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
+    You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-  If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:
-
-    <program>  Copyright (C) <year>  <name of author>
-    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, your program's commands
-might be different; for a GUI interface, you would use an "about box".
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
 
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
+For more information on this, and how to apply and follow the GNU AGPL, see
 <https://www.gnu.org/licenses/>.
-
-  The GNU General Public License does not permit incorporating your program
-into proprietary programs.  If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.  But first, please read
-<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,27 @@
+# Licensing notice
+
+OnyxZygisk as a whole is distributed under the **GNU Affero General Public
+License v3.0** (`LICENSE`).
+
+The project incorporates several works under their own licenses:
+
+| Component | Path | License |
+| :--- | :--- | :--- |
+| CSOLoader (in-process ELF loader) | `loader/src/external/csoloader/` | AGPL-3.0 |
+| NeoZygisk (the base OnyxZygisk forked from) | most of `loader/`, `zygiskd/`, `module/` | GPL-3.0 |
+| LSPlt (PLT hooking) | `loader/src/external/lsplt/` | its own license, retained |
+
+## Why the combined work is AGPL-3.0
+
+OnyxZygisk began as a downstream of NeoZygisk (GPL-3.0). Integrating CSOLoader
+(AGPL-3.0) as the in-process custom module loader brings AGPL-3.0 code into the
+combined work. Section 13 of the GPL-3.0 explicitly permits linking a
+GPL-3.0 work with an AGPL-3.0 work; the resulting combination is conveyed under
+the AGPL-3.0, whose additional network-interaction source-offer requirement then
+applies to the whole.
+
+The original GPL-3.0 files retain their own copyright notices and GPL-3.0
+terms; nothing here removes NeoZygisk's or any upstream author's attribution.
+Distributing OnyxZygisk means complying with the AGPL-3.0 for the combined work.
+
+See `docs/CUSTOM_LINKER.md` for how CSOLoader is used.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A **ptrace-based Zygisk implementation** for **APatch** & **KernelSU** — with 
 
 **English** · [简体中文](README.zh-CN.md) · [繁體中文](README.zh-TW.md) · [日本語](README.ja.md)
 
-[![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](LICENSE)
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
 
 </div>
 
@@ -61,4 +61,4 @@ OnyxZygisk stands on the shoulders of the projects it is built from and inspired
 
 ## License
 
-[GPL-3.0](LICENSE). OnyxZygisk is a downstream of NeoZygisk and keeps the same license and notices.
+[AGPL-3.0](LICENSE). OnyxZygisk is a downstream of NeoZygisk (GPL-3.0) and integrates CSOLoader (AGPL-3.0) as its in-process custom module loader; per GPL-3.0 §13 the combined work is conveyed under AGPL-3.0. Upstream GPL-3.0 notices are retained — see [NOTICE.md](NOTICE.md).

--- a/docs/CUSTOM_LINKER.md
+++ b/docs/CUSTOM_LINKER.md
@@ -13,29 +13,22 @@ Today OnyxZygisk is **reactive**: the system linker loads the module via
 loader is **proactive**: the module is mapped, relocated and initialised by our
 own code and never enters `solist` in the first place.
 
-This is the same technique ReZygisk markets under "custom linker (CSOLoader)".
-The *idea* is shared; the *code* here is not — see Licensing.
+The loader itself is **CSOLoader** (github.com/ThePedroo/CSOLoader), the same
+component ReZygisk uses, vendored as a git submodule under
+`loader/src/external/csoloader/`.
 
-## Licensing (hard constraint)
+## Licensing
 
-- OnyxZygisk is **GPL-3.0** (inherited from NeoZygisk, upstream GPL-3.0).
-- ReZygisk's `CSOLoader` (github.com/ThePedroo/CSOLoader) is **AGPL-3.0**.
+- NeoZygisk (the base) is **GPL-3.0**.
+- CSOLoader is **AGPL-3.0**.
 
-AGPL-3.0 source must not be copied or adapted into this project: doing so would
-force AGPL obligations onto the whole work (GPLv3 §13 permits the combination,
-but that is a deliberate relicensing the project has chosen **not** to make).
-"Read it and write a similar one" is not a loophole — access plus substantial
-similarity makes a derivative work regardless of rewording.
-
-Therefore the loader here is written **only** from:
-
-- the public **ELF** and **AArch64 / ARM ELF ABI** specifications;
-- Android's **bionic** linker, which is **Apache-2.0** (GPL-compatible), used as
-  a reference for Android-specific behaviour;
-- this repository's own GPL-3.0 code (`injector/solist.cpp`,
-  `include/elf_parser.hpp`, `include/linker_soinfo.h`).
-
-No CSOLoader / ReZygisk source is consulted while implementing it.
+The project decision is to incorporate CSOLoader directly rather than
+reimplement it. GPL-3.0 §13 permits linking a GPL-3.0 work with an AGPL-3.0
+work; the combined work is therefore conveyed under **AGPL-3.0** (`LICENSE`),
+with upstream GPL-3.0 notices retained (`NOTICE.md`). CSOLoader is kept as an
+unmodified submodule so its copyright headers and AGPL license stay intact; our
+own code only calls its public API (`csoloader_load`, `csoloader_get_symbol`,
+`csoloader_unload`).
 
 ## The seam
 
@@ -53,31 +46,25 @@ This decouples the call sites from *how* the library was loaded.
 ## Stages
 
 **Stage 1 — the seam (done).**
-`LoadModuleFromMemfd` wraps the previous `DlopenMem` + `dlsym` exactly;
-`custom` is always `false`. No behavioural change. Both call sites converted.
-Purpose: a single, testable place to add the custom path with a guaranteed
-fallback.
+`LoadModuleFromMemfd` funnels both module load sites through one function.
 
-**Stage 2 — read-only ELF loader, dry run.**
-Parse the module image from the memfd (program headers, dynamic section,
-relocation and symbol tables) and log what a load *would* do — segment layout,
-`DT_NEEDED` list, relocation counts — but still hand the process off to
-`DlopenMem`. Lets us validate the parser against real modules on-device with
-zero risk to boot.
+**Stage 2 — vendor CSOLoader + wire the build (done).**
+CSOLoader added as a submodule; its static `csoloader` target is built by the
+NDK and linked into `zygisk`. Combined work relicensed to AGPL-3.0.
 
-**Stage 3 — map + relocate + init, behind a flag.**
-Actually `mmap` the `PT_LOAD` segments, apply relocations
-(`R_AARCH64_RELATIVE`, `R_AARCH64_GLOB_DAT`, `R_AARCH64_JUMP_SLOT`,
-`R_AARCH64_ABS64`; ARM equivalents for 32-bit), resolve imports against
-already-loaded libraries via the in-process linker's own lookup, run
-`DT_INIT` / `DT_INIT_ARRAY`, and return a handle whose `dlsym` equivalent finds
-`zygisk_module_entry`. Gated by a compile-time flag (default off) **and** an
-automatic fallback: any failure in the custom path returns to `DlopenMem`, so a
-bug degrades to today's working behaviour instead of failing specialization.
+**Stage 3 — in-process glue behind a flag (done, default off).**
+`LoadModuleFromMemfd` can load a module via `csoloader_load` on the memfd's
+procfs path (`/proc/self/fd/<n>`), resolve `zygisk_module_entry` with
+`csoloader_get_symbol`, and returns a `custom` handle. Gated by the
+`USE_CUSTOM_LOADER` compile flag (default `0`) with an automatic fallback: any
+failure in the custom path returns to `DlopenMem`, so a bug degrades to today's
+working behaviour instead of failing specialization. Both the default-off and
+flag-on builds compile and link for all four ABIs.
 
-**Stage 4 — make it the default, keep the fallback.**
-Flip the default once it has been proven on a range of devices / Android
-versions. `dropSoPath` stays as a belt-and-braces cleanup for the fallback path.
+**Stage 4 — make it the default, keep the fallback (pending on-device work).**
+Flip `USE_CUSTOM_LOADER` to `1` once it has been proven on a range of devices /
+Android versions (see verification below). `dropSoPath` stays as a
+belt-and-braces cleanup for the fallback path.
 
 ## Risk & verification
 

--- a/loader/src/CMakeLists.txt
+++ b/loader/src/CMakeLists.txt
@@ -21,7 +21,7 @@ aux_source_directory(injector INJECTOR_SRC_LIST)
 add_library(zygisk SHARED ${INJECTOR_SRC_LIST})
 target_compile_options(zygisk PRIVATE -Wno-invalid-offsetof -Wno-unused-private-field)
 target_include_directories(zygisk PRIVATE include)
-target_link_libraries(zygisk log common lsplt_static)
+target_link_libraries(zygisk log common lsplt_static csoloader)
 
 aux_source_directory(ptracer PTRACER_SRC_LIST)
 add_executable(libzygisk_ptrace.so ${PTRACER_SRC_LIST})

--- a/loader/src/common/module_loader.cpp
+++ b/loader/src/common/module_loader.cpp
@@ -1,23 +1,42 @@
 #include "module_loader.hpp"
 
+#include <cstdio>
+
 #include "dl.hpp"
 #include "logging.hpp"
 
+extern "C" {
+#include "../external/csoloader/include/csoloader.h"
+}
+
 /*
- * Stage 1: the seam only. This routes both module load sites through a single
- * function while preserving the exact behaviour of the previous inline
- * `DlopenMem(memfd, RTLD_NOW)` + `dlsym(handle, "zygisk_module_entry")` pair.
+ * Module loading seam.
  *
- * Stage 2 will add the in-process custom loader here, tried first and falling
- * back to this system-linker path on any failure, behind a build/runtime flag.
- * Keeping the fallback is what makes the custom path safe to iterate on: a bug
- * in it degrades to the working linker instead of failing to specialize the
- * process.
+ * Two paths live here:
+ *
+ *  - the system linker (DlopenMem -> android_dlopen_ext), which registers the
+ *    library in the linker's solist and is cleaned up afterwards by
+ *    injector/solist.cpp:dropSoPath; and
+ *  - the in-process custom loader (CSOLoader), which maps and links the module
+ *    itself, so it never enters solist at all.
+ *
+ * The custom path is tried first only when USE_CUSTOM_LOADER is enabled, and it
+ * falls back to the system linker on any failure. That fallback is what makes
+ * it safe to iterate on: a bug in the custom loader degrades to today's working
+ * behaviour instead of failing to specialize the process (which would boot
+ * loop). It is OFF by default until proven on-device — see docs/CUSTOM_LINKER.md.
  */
+
+// Flip to 1 (or pass -DUSE_CUSTOM_LOADER=1) to make the custom loader the
+// primary path. Keep the fallback regardless.
+#ifndef USE_CUSTOM_LOADER
+#define USE_CUSTOM_LOADER 0
+#endif
 
 static constexpr const char *ENTRY_SYMBOL = "zygisk_module_entry";
 
-LoadedModule LoadModuleFromMemfd(int memfd) {
+/// System-linker path: android_dlopen_ext from the memfd, then resolve entry.
+static LoadedModule LoadViaSystemLinker(int memfd) {
     LoadedModule out;
 
     void *handle = DlopenMem(memfd, RTLD_NOW);
@@ -37,4 +56,48 @@ LoadedModule LoadModuleFromMemfd(int memfd) {
     out.entry = entry;
     out.custom = false;
     return out;
+}
+
+#if USE_CUSTOM_LOADER
+/// Custom-loader path: map + link the module in-process via CSOLoader, so it
+/// never enters the system linker's solist. Returns a falsy LoadedModule on any
+/// failure so the caller can fall back to the system linker.
+static LoadedModule LoadViaCustomLinker(int memfd) {
+    LoadedModule out;
+
+    // CSOLoader loads by path; a memfd is reachable through its procfs link.
+    char path[64];
+    snprintf(path, sizeof(path), "/proc/self/fd/%d", memfd);
+
+    auto *lib = new csoloader{};
+    if (!csoloader_load(lib, path)) {
+        LOGW("custom loader failed for fd %d (%s); falling back", memfd, path);
+        delete lib;
+        return out;
+    }
+
+    void *entry = csoloader_get_symbol(lib, ENTRY_SYMBOL);
+    if (!entry) {
+        LOGW("custom-loaded module has no `%s` symbol; falling back", ENTRY_SYMBOL);
+        csoloader_unload(lib);
+        delete lib;
+        return out;
+    }
+
+    out.handle = lib;  // opaque; freed via the custom path's unload
+    out.entry = entry;
+    out.custom = true;
+    return out;
+}
+#endif  // USE_CUSTOM_LOADER
+
+LoadedModule LoadModuleFromMemfd(int memfd) {
+#if USE_CUSTOM_LOADER
+    if (LoadedModule lm = LoadViaCustomLinker(memfd)) {
+        LOGV("loaded module from fd %d via custom linker", memfd);
+        return lm;
+    }
+    // Custom path failed — fall through to the always-available system linker.
+#endif
+    return LoadViaSystemLinker(memfd);
 }

--- a/loader/src/external/CMakeLists.txt
+++ b/loader/src/external/CMakeLists.txt
@@ -2,3 +2,8 @@ project(external)
 
 OPTION(LSPLT_BUILD_SHARED OFF)
 add_subdirectory(lsplt/lsplt/src/main/jni)
+
+# CSOLoader — traceless, system-linker-independent ELF loader (AGPL-3.0).
+# Vendored as a git submodule; builds a static `csoloader` target from its own
+# CMakeLists. Its presence makes the combined work AGPL-3.0 — see LICENSE.
+add_subdirectory(csoloader)


### PR DESCRIPTION
Brings ReZygisk's custom-linker capability into OnyxZygisk by vendoring the actual **CSOLoader** and wiring it in behind the module-loading seam from #17. Modules can be mapped and linked **in-process** so they never enter the system linker's `solist` — proactive hiding, instead of the current reactive `dropSoPath` cleanup.

## What's integrated

- **CSOLoader** (github.com/ThePedroo/CSOLoader) vendored as a submodule at `loader/src/external/csoloader/`, unmodified, with its AGPL license and copyright headers intact.
- Its static `csoloader` target is built by the NDK and linked into `libzygisk.so`.
- `LoadModuleFromMemfd` gains a custom path: `csoloader_load` on the memfd's procfs path (`/proc/self/fd/<n>`) → `csoloader_get_symbol("zygisk_module_entry")`.

## Safety — default off, always falls back

Gated by the `USE_CUSTOM_LOADER` compile flag (**default `0`**) with an automatic fallback to `DlopenMem` on any failure. So:
- the shipped **default runtime is unchanged** (system linker + existing `dropSoPath`);
- a bug in the custom path degrades to the working system-linker path rather than failing specialization (which would boot loop).

Verified: **both** the default-off and flag-on builds compile and link for all four ABIs. Flipping the flag on cleanly resolves `csoloader_load` / `csoloader_get_symbol` / `csoloader_unload`.

## License change (as decided)

CSOLoader is **AGPL-3.0**. Per **GPL-3.0 §13**, linking it makes the combined work AGPL-3.0:
- `LICENSE` now carries the AGPL-3.0 text;
- `NOTICE.md` records the combined licensing and **retains NeoZygisk's GPL-3.0 attribution** (GPL requires keeping upstream notices);
- README badge/section updated.

## Not in this PR

Making the custom loader the **default** (flag → `1`) is deferred until it's verified on real hardware — boot-loop-class changes can't be validated on emulators/CI. The on-device checklist is in `docs/CUSTOM_LINKER.md` (Stage 4).
