### PR TITLE
feat(loader): make the CSOLoader custom loader the default path

### DIFF
--- a/docs/CUSTOM_LINKER.md
+++ b/docs/CUSTOM_LINKER.md
@@ -61,10 +61,16 @@ failure in the custom path returns to `DlopenMem`, so a bug degrades to today's
 working behaviour instead of failing specialization. Both the default-off and
 flag-on builds compile and link for all four ABIs.
 
-**Stage 4 — make it the default, keep the fallback (pending on-device work).**
-Flip `USE_CUSTOM_LOADER` to `1` once it has been proven on a range of devices /
-Android versions (see verification below). `dropSoPath` stays as a
-belt-and-braces cleanup for the fallback path.
+**Stage 4 — custom loader is the default (done in code; on-device validation
+ongoing).**
+`USE_CUSTOM_LOADER` now defaults to `1`, so CSOLoader is the primary path for
+every module load, with the system-linker fallback kept for load-time failures.
+`dropSoPath` stays as belt-and-braces cleanup for whenever the fallback fires.
+Build with `-DUSE_CUSTOM_LOADER=0` to force the old system-linker path if a
+regression needs isolating. The on-device checklist below still governs whether
+this default is safe on a given device / Android version — the fallback does not
+cover a load that succeeds but yields a broken module (a zygote crash / boot
+loop), so real-hardware testing remains required.
 
 ## Risk & verification
 

--- a/loader/src/common/module_loader.cpp
+++ b/loader/src/common/module_loader.cpp
@@ -20,17 +20,18 @@ extern "C" {
  *  - the in-process custom loader (CSOLoader), which maps and links the module
  *    itself, so it never enters solist at all.
  *
- * The custom path is tried first only when USE_CUSTOM_LOADER is enabled, and it
- * falls back to the system linker on any failure. That fallback is what makes
- * it safe to iterate on: a bug in the custom loader degrades to today's working
- * behaviour instead of failing to specialize the process (which would boot
- * loop). It is OFF by default until proven on-device — see docs/CUSTOM_LINKER.md.
+ * The custom path is the primary one: it is tried first and falls back to the
+ * system linker if csoloader_load fails or the entry symbol is missing. The
+ * fallback catches load-time failures — but note it cannot catch a load that
+ * succeeds yet yields a subtly broken module, which would surface as a zygote
+ * crash. See docs/CUSTOM_LINKER.md for the on-device verification this needs.
  */
 
-// Flip to 1 (or pass -DUSE_CUSTOM_LOADER=1) to make the custom loader the
-// primary path. Keep the fallback regardless.
+// Custom loader is the default primary path. Set -DUSE_CUSTOM_LOADER=0 to force
+// the system linker (e.g. to isolate a regression). The fallback is kept
+// regardless.
 #ifndef USE_CUSTOM_LOADER
-#define USE_CUSTOM_LOADER 0
+#define USE_CUSTOM_LOADER 1
 #endif
 
 static constexpr const char *ENTRY_SYMBOL = "zygisk_module_entry";


### PR DESCRIPTION
Flips `USE_CUSTOM_LOADER` to default **1** (Stage 4). CSOLoader is now the primary path for every Zygisk/FN module load — mapped and linked in-process so it never enters the system linker's `solist`. This turns on the proactive hiding for real.

## What changes at runtime

- Every module load goes through `csoloader_load` first.
- System-linker fallback kept: a `csoloader_load` failure or missing `zygisk_module_entry` still degrades to `DlopenMem`.
- `dropSoPath` remains as cleanup for whenever the fallback fires.
- `-DUSE_CUSTOM_LOADER=0` forces the old system-linker path to isolate a regression.

## Honest risk statement

The fallback covers **load-time failures only**. It cannot catch a load that *succeeds but yields a subtly broken module* — that surfaces as a zygote crash, i.e. a **boot loop**, and it's exactly the class of bug emulators/CI can't reveal. This PR is verified to compile and link on all four ABIs with the custom path as default; **whether it boots must be confirmed on real hardware** per the checklist in `docs/CUSTOM_LINKER.md`.

Recommended before flashing to a daily driver: test on a spare device / with a way to recover (fastboot, recovery, or `magisk --remove-modules`), toggling back via `-DUSE_CUSTOM_LOADER=0` if needed.
