### PR TITLE
fix(loader): unload custom-loaded modules through csoloader, not dlclose

### DIFF
--- a/docs/CUSTOM_LINKER.md
+++ b/docs/CUSTOM_LINKER.md
@@ -72,6 +72,33 @@ this default is safe on a given device / Android version — the fallback does n
 cover a load that succeeds but yields a broken module (a zygote crash / boot
 loop), so real-hardware testing remains required.
 
+**Stage 5 — full lifecycle: unload + global teardown (done).**
+Making the loader the default surfaced a real gap: `ZygiskModule::tryUnload()`
+(called whenever a module opts into `zygisk::Option::DLCLOSE_MODULE_LIBRARY` —
+a normal, common thing modules do) unconditionally called `dlclose(handle)`.
+For a custom-loaded module `handle` is a `csoloader*`, not a `dlopen()` handle,
+so this was undefined behaviour on every such module once Stage 4 shipped.
+
+Fixed by giving `ZygiskModule` a `custom` bit (threaded through from
+`LoadedModule::custom` at both call sites) and a matching `UnloadModule(handle,
+custom)` in the seam that dispatches to `dlclose()` or `csoloader_unload()`
+accordingly. `csoloader_unload()` is csoloader's dlclose equivalent — it unmaps
+the module's segments and frees its per-load bookkeeping; the `csoloader`
+struct itself (heap-allocated in `LoadViaCustomLinker`) is freed alongside it.
+
+There is also a process-global piece: `csoloader_deinit()` (`linker_deinit()`
+in the vendored source) tears down TLS bookkeeping **shared by every
+custom-loaded module in the process**, not just the one being unloaded. Calling
+it while any custom-loaded module is still resident — the common case, since
+most modules never request `DLCLOSE_MODULE_LIBRARY` and stay loaded for the
+app's whole lifetime to keep their hooks active — would corrupt that module's
+TLS. So `DeinitCustomLoaderIfUsed()` only runs from `run_modules_post()`,
+inside the existing `modules.size() == modules_unloaded` branch (the same
+guard that already gates `clean_libc_trace()`): i.e. only once *every* module
+loaded in this process, custom or not, has actually been torn down. It is a
+no-op if the custom loader was never invoked in this process, and idempotent
+if called twice.
+
 ## Risk & verification
 
 A wrong loader means **zygote cannot load the module → boot loop**. This class
@@ -90,8 +117,14 @@ Required on-device checks before advancing a stage:
 
 ## Files
 
-- `include/module_loader.hpp` — the seam interface.
-- `common/module_loader.cpp` — Stage 1 implementation (system-linker wrapper);
-  the custom loader lands here behind the fallback.
+- `include/module_loader.hpp` — the seam interface: `LoadModuleFromMemfd`,
+  `UnloadModule`, `DeinitCustomLoaderIfUsed`.
+- `common/module_loader.cpp` — both load paths, the unload dispatch, and the
+  guarded global teardown.
 - `common/dl.cpp` — `DlopenMem`, the system-linker path / fallback.
-- `injector/solist.cpp` — existing reactive `solist` cleanup, retained.
+- `injector/solist.cpp` — existing reactive `solist` cleanup, retained for the
+  system-linker path.
+- `injector/module.cpp` — `ZygiskModule::tryUnload()` and the
+  `run_modules_post()` full-unload gate that also calls
+  `DeinitCustomLoaderIfUsed()`.
+- `external/csoloader/` — the vendored submodule itself.

--- a/loader/src/common/module_loader.cpp
+++ b/loader/src/common/module_loader.cpp
@@ -92,13 +92,43 @@ static LoadedModule LoadViaCustomLinker(int memfd) {
 }
 #endif  // USE_CUSTOM_LOADER
 
+// Set once a module in this process was actually loaded via the custom
+// loader. Gates DeinitCustomLoaderIfUsed() so it never touches csoloader's
+// global state when nothing here ever initialized it (calling
+// csoloader_deinit() with no prior csoloader_load() would delete a pthread
+// TLS key that was never created).
+static bool g_used_custom_loader = false;
+
 LoadedModule LoadModuleFromMemfd(int memfd) {
 #if USE_CUSTOM_LOADER
     if (LoadedModule lm = LoadViaCustomLinker(memfd)) {
         LOGV("loaded module from fd %d via custom linker", memfd);
+        g_used_custom_loader = true;
         return lm;
     }
     // Custom path failed — fall through to the always-available system linker.
 #endif
     return LoadViaSystemLinker(memfd);
+}
+
+bool UnloadModule(void *handle, bool custom) {
+    if (!custom) return dlclose(handle) == 0;
+
+    // csoloader_unload() is csoloader's dlclose equivalent: it unmaps the
+    // library's segments and tears down its per-load bookkeeping. The
+    // `csoloader` struct itself was heap-allocated in LoadViaCustomLinker and
+    // is ours to free.
+    auto *lib = static_cast<csoloader *>(handle);
+    bool ok = csoloader_unload(lib);
+    if (!ok) LOGW("csoloader_unload failed for handle %p", handle);
+    delete lib;
+    return ok;
+}
+
+void DeinitCustomLoaderIfUsed() {
+    if (!g_used_custom_loader) return;
+    csoloader_deinit();
+    // Defensive: a second call in the same process becomes a no-op rather
+    // than tearing down already-torn-down global state.
+    g_used_custom_loader = false;
 }

--- a/loader/src/include/module_loader.hpp
+++ b/loader/src/include/module_loader.hpp
@@ -41,3 +41,29 @@ struct LoadedModule {
  *         load or the symbol lookup failed.
  */
 LoadedModule LoadModuleFromMemfd(int memfd);
+
+/**
+ * @brief Unload a module handle previously returned by LoadModuleFromMemfd.
+ *
+ * Dispatches to dlclose() for a system-linker handle, or to the custom
+ * loader's own teardown (which also frees its bookkeeping struct) for one
+ * loaded in-process. `handle` must not be used again after this call either
+ * way.
+ *
+ * @param handle LoadedModule::handle from the original load.
+ * @param custom LoadedModule::custom from the same load.
+ * @return true on success.
+ */
+bool UnloadModule(void *handle, bool custom);
+
+/**
+ * @brief Tear down the custom loader's process-wide global state.
+ *
+ * Safe to call unconditionally — a no-op if the custom loader was never used
+ * in this process. Must only be called once every module this process loaded
+ * through it has also been unloaded via UnloadModule(): the teardown releases
+ * TLS bookkeeping that a still-resident custom-loaded module (one that never
+ * asked to unload — the common case) would depend on, so calling it early
+ * corrupts that module's state instead of merely leaking memory.
+ */
+void DeinitCustomLoaderIfUsed();

--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -21,8 +21,8 @@
 
 using namespace std;
 
-ZygiskModule::ZygiskModule(int id, void *handle, void *entry)
-    : id(id), handle(handle), entry{entry}, api{}, mod{nullptr} {
+ZygiskModule::ZygiskModule(int id, void *handle, void *entry, bool custom)
+    : id(id), handle(handle), custom(custom), entry{entry}, api{}, mod{nullptr} {
     // Make sure all pointers are null
     memset(&api, 0, sizeof(api));
     api.base.impl = this;
@@ -104,7 +104,7 @@ void ZygiskModule::setOption(zygisk::Option opt) {
 
 uint32_t ZygiskModule::getFlags() { return g_ctx ? (g_ctx->info_flags & ~PRIVATE_MASK) : 0; }
 
-bool ZygiskModule::tryUnload() const { return unload && dlclose(handle) == 0; }
+bool ZygiskModule::tryUnload() const { return unload && UnloadModule(handle, custom); }
 
 // -----------------------------------------------------------------
 
@@ -335,7 +335,7 @@ void ZygiskContext::run_modules_pre() {
     for (size_t i = 0; i < size; i++) {
         auto &m = ms[i];
         if (LoadedModule lm = LoadModuleFromMemfd(m.memfd)) {
-            modules.emplace_back(i, lm.handle, lm.entry);
+            modules.emplace_back(i, lm.handle, lm.entry, lm.custom);
         }
     }
 
@@ -354,7 +354,7 @@ void ZygiskContext::run_modules_pre() {
         if (LoadedModule lm = LoadModuleFromMemfd(fn.memfd)) {
             LOGI("loading FN module `%s` into %s (priority %u)", fn.id.c_str(),
                  is_server ? "system_server" : process ? process : "unknown", fn.priority);
-            modules.emplace_back(size + i, lm.handle, lm.entry);
+            modules.emplace_back(size + i, lm.handle, lm.entry, lm.custom);
         }
     }
 
@@ -383,7 +383,15 @@ void ZygiskContext::run_modules_post() {
 
     if (modules.size() > 0) {
         LOGV("modules unloaded: %zu/%zu", modules_unloaded, modules.size());
-        if (modules.size() == modules_unloaded) clean_libc_trace();
+        if (modules.size() == modules_unloaded) {
+            clean_libc_trace();
+            // Only safe once every module this process loaded — custom or
+            // system-linker — is actually gone: a still-resident
+            // custom-loaded module (one that didn't ask to unload) depends on
+            // the custom loader's global TLS bookkeeping for as long as it
+            // keeps running.
+            DeinitCustomLoaderIfUsed();
+        }
         clean_linker_trace("jit-cache-zygisk", modules.size(), modules_unloaded, true);
         g_hook->should_spoof_maps =
             (flags & APP_SPECIALIZE) && (modules.size() - modules_unloaded) > 0;

--- a/loader/src/injector/module.hpp
+++ b/loader/src/injector/module.hpp
@@ -212,7 +212,7 @@ struct ZygiskModule {
     void clearApi() { memset(&api, 0, sizeof(api)); }
     int getId() const { return id; }
 
-    ZygiskModule(int id, void *handle, void *entry);
+    ZygiskModule(int id, void *handle, void *entry, bool custom);
 
     static bool RegisterModuleImpl(ApiTable *api, long *module);
 
@@ -221,6 +221,9 @@ private:
     bool unload = false;
 
     void *const handle;
+    // True if `handle` came from the in-process custom loader rather than
+    // dlopen(); tryUnload() needs this to call the matching teardown.
+    const bool custom;
     union {
         void *const ptr;
         void (*const fn)(void *, void *);


### PR DESCRIPTION
Making the custom loader the default (previous PR) exposed a real bug, not just an incompleteness: **using it "fully" means the unload and global-teardown paths too, not just load.**

## The bug

`ZygiskModule::tryUnload()` unconditionally called `dlclose(handle)`. For a custom-loaded module, `handle` is a `csoloader*` struct pointer, not a real `dlopen()` handle. This function runs whenever a module calls the standard `zygisk::Option::DLCLOSE_MODULE_LIBRARY` — a normal, common thing modules do — so this was live undefined behavior on **every** such module once the previous PR shipped.

## The fix

Rather than guess at teardown semantics on a boot-critical path, I read the vendored CSOLoader implementation (`external/csoloader/src/{csoloader,linker}.c` — legitimate now that it's incorporated directly, not the clean-room path) to confirm the correct calls:

- `ZygiskModule` now carries the `custom` bit from `LoadedModule` (threaded through both load call sites in `run_modules_pre`).
- `tryUnload()` dispatches through a new `UnloadModule(handle, custom)` in the loading seam: `dlclose()` for a system-linker handle, `csoloader_unload()` (confirmed to be csoloader's dlclose equivalent — unmaps segments, tears down per-load bookkeeping) + freeing our heap-allocated wrapper for a custom one.
- `csoloader_deinit()` is now also called — but carefully. Reading `linker_deinit()`'s implementation shows it tears down **TLS bookkeeping shared by every custom-loaded module in the process**, not just the one being unloaded. Calling it while any custom-loaded module is still resident (the common case — most modules never request `DLCLOSE_MODULE_LIBRARY` and stay loaded for the app's whole life to keep their hooks active) would corrupt that module's TLS. So `DeinitCustomLoaderIfUsed()` only fires from inside the existing `modules.size() == modules_unloaded` branch in `run_modules_post()` — the same guard that already gates `clean_libc_trace()` — meaning it only runs once *every* module in the process, custom or not, has actually been torn down. No-op if the custom loader was never used in this process; idempotent if called twice.

## Verification

Both `USE_CUSTOM_LOADER=1` (shipped default) and `=0` configs compile and link for all four ABIs. Full lifecycle (load → resolve → unload → conditional global teardown) is now consistent for both loading paths.

`docs/CUSTOM_LINKER.md` updated (Stage 5) with the reasoning above.
