### PR TITLE
feat(webui): require an explicit per-module switch before hot-plugging a staged update

### DIFF
--- a/zygiskd/src/zygiskd.rs
+++ b/zygiskd/src/zygiskd.rs
@@ -283,20 +283,35 @@ fn staged_update_ready(root: root_impl::RootImpl, name: &str) -> bool {
     }
 }
 
+/// Whether the user explicitly opted `name` into using its staged update
+/// early, via the WebUI's per-module switch (`WORKDIR/hotplug/<name>`,
+/// touched/removed exactly like the `disable`/`update`/`remove` flags
+/// elsewhere in this project).
+///
+/// `staged_update_ready` alone only proves the staged copy is *safe* to
+/// read; it says nothing about whether the user *wants* it read before the
+/// root solution's own official boot-time commit. Requiring this opt-in too
+/// turns that automatic behavior into an explicit, per-module confirmation.
+fn hotplug_opted_in(name: &str) -> bool {
+    Path::new(TMP_PATH.get().unwrap()).join("hotplug").join(name).exists()
+}
+
 /// Names and directories of every module eligible for Zygisk injection,
 /// sorted by name. Two sources are merged:
 ///
 /// - `PATH_MODULES_DIR`, the active directory — today's baseline;
 /// - for KernelSU and APatch, any module with a *complete* staged update in
-///   `PATH_MODULES_UPDATE_DIR` (see `staged_update_ready`). A staged entry
-///   wins over an active one with the same name (it is the newer version);
-///   its disabled state is inherited from the active entry, mirroring
-///   exactly what `ksud`'s / `apd`'s own boot-time swap does ("if the old
-///   module is disabled, the new one starts disabled too").
+///   `PATH_MODULES_UPDATE_DIR` that the user has also explicitly opted into
+///   (see `staged_update_ready` and `hotplug_opted_in`). A staged entry wins
+///   over an active one with the same name (it is the newer version); its
+///   disabled state is inherited from the active entry, mirroring exactly
+///   what `ksud`'s / `apd`'s own boot-time swap does ("if the old module is
+///   disabled, the new one starts disabled too").
 ///
 /// This is what lets a freshly installed or updated module become
 /// injectable on the very next process fork, instead of waiting for the
-/// boot-time swap the root solution itself performs.
+/// boot-time swap the root solution itself performs — once the user
+/// confirms it, via the WebUI's per-module switch.
 ///
 /// Sorting keeps the order deterministic across the several independent
 /// re-scans a single process specialize can trigger (`ReadModules`, then
@@ -324,7 +339,7 @@ fn eligible_modules(arch: &str) -> Vec<(String, PathBuf)> {
     if let Ok(dir) = fs::read_dir(constants::PATH_MODULES_UPDATE_DIR) {
         for entry in dir.flatten() {
             let name = entry.file_name().into_string().unwrap_or_default();
-            if !staged_update_ready(*root, &name) {
+            if !staged_update_ready(*root, &name) || !hotplug_opted_in(&name) {
                 continue;
             }
             let module_dir = entry.path();

--- a/zygiskd/webui/src/api/system.test.ts
+++ b/zygiskd/webui/src/api/system.test.ts
@@ -12,8 +12,8 @@ describe("parseStatus", () => {
     "\tmonitor:\ttracing",
     "",
     "@@modules",
-    "M|playintegrityfix|Play Integrity Fix|v18.8|chiteroman|1|0|修复认证",
-    "M|tricky_store|Tricky Store|v1.2.1|5ec1cff|1|1|在 TEE 上伪造 keybox",
+    "M|playintegrityfix|Play Integrity Fix|v18.8|chiteroman|1|0|修复认证|0|0",
+    "M|tricky_store|Tricky Store|v1.2.1|5ec1cff|1|1|在 TEE 上伪造 keybox|0|0",
     "@@fn",
     "F|net_guard|网络守卫|1.0|app|com.bank.*|enabled",
     "F|prop_shield|属性护盾|2.1|system_server|all|disabled",
@@ -44,6 +44,8 @@ describe("parseStatus", () => {
       zygisk: true,
       disabled: false,
       desc: "修复认证",
+      pendingUpdate: false,
+      hotplugEnabled: false,
     });
     expect(d.modules[1].disabled).toBe(true);
   });

--- a/zygiskd/webui/src/api/system.ts
+++ b/zygiskd/webui/src/api/system.ts
@@ -42,7 +42,21 @@ const STATUS_SCRIPT = [
   '  dis=0; [ -f "$d/disable" ] && dis=1',
   // Only Zygisk-capable modules are shown in the WebUI.
   '  [ "$zy" = 0 ] && continue',
-  '  echo "M|$id|$nm|$ver|$au|$zy|$dis|$ds"',
+  // A newer version staged by the root manager (KernelSU/APatch), confirmed
+  // fully written by that root solution's own "install finished" signal —
+  // same check the daemon itself uses, see zygiskd::staged_update_ready.
+  // FolkPatch reuses APatch's apd and its staging convention.
+  '  pend=0',
+  '  if [ "$r" = "KernelSU" ]; then',
+  '    [ -f "/data/adb/modules/$id/update" ] && pend=1',
+  '  elif [ "$r" = "APatch" ] || [ "$r" = "FolkPatch" ]; then',
+  '    if [ -f "/data/adb/ap/update" ]; then',
+  '      [ -f "/data/adb/modules_update/$id/zygisk/arm64-v8a.so" ] && pend=1',
+  '      [ -f "/data/adb/modules_update/$id/zygisk/armeabi-v7a.so" ] && pend=1',
+  '    fi',
+  '  fi',
+  '  hp=0; [ -f "$W/hotplug/$id" ] && hp=1',
+  '  echo "M|$id|$nm|$ver|$au|$zy|$dis|$ds|$pend|$hp"',
   "done",
   'echo "@@fn"',
   'for d in "$W"/fn/*/; do',
@@ -90,6 +104,8 @@ export function parseStatus(out: string): StateData {
         zygisk: p[5] === "1",
         disabled: p[6] === "1",
         desc: p[7],
+        pendingUpdate: p[8] === "1",
+        hotplugEnabled: p[9] === "1",
       } as ModuleInfo);
     } else if (section === "fn" && line.startsWith("F|")) {
       const p = line.split("|");
@@ -143,6 +159,16 @@ export async function fetchLogs(lines: number | string): Promise<string> {
 export async function setFnEnabled(id: string, enabled: boolean): Promise<void> {
   const flag = `${WORKDIR}/fn/${id}/disable`;
   await exec(enabled ? `rm -f '${flag}'` : `touch '${flag}'`);
+}
+
+/** Opt a module with a detected pending update into using it immediately —
+ * the daemon only overlays a staged update when both this flag and the root
+ * solution's own "install finished" signal are present. See
+ * zygiskd::eligible_modules. */
+export async function setModuleHotplug(id: string, enabled: boolean): Promise<void> {
+  const dir = `${WORKDIR}/hotplug`;
+  const flag = `${dir}/${id}`;
+  await exec(enabled ? `mkdir -p '${dir}' && touch '${flag}'` : `rm -f '${flag}'`);
 }
 
 /** Normalize version display: strip a leading v/V then add one. */

--- a/zygiskd/webui/src/components/ModulesSection.test.ts
+++ b/zygiskd/webui/src/components/ModulesSection.test.ts
@@ -5,10 +5,10 @@ import type { StateData } from "../types";
 
 vi.mock("../api/system", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../api/system")>();
-  return { ...actual, fetchState: vi.fn() };
+  return { ...actual, fetchState: vi.fn(), setModuleHotplug: vi.fn() };
 });
 
-import { fetchState } from "../api/system";
+import { fetchState, setModuleHotplug } from "../api/system";
 
 const state = (over: Partial<StateData> = {}): StateData => ({
   keys: {},
@@ -22,6 +22,8 @@ const state = (over: Partial<StateData> = {}): StateData => ({
       zygisk: true,
       disabled: false,
       desc: "修复认证",
+      pendingUpdate: false,
+      hotplugEnabled: false,
     },
     {
       id: "tricky_store",
@@ -31,6 +33,8 @@ const state = (over: Partial<StateData> = {}): StateData => ({
       zygisk: true,
       disabled: true,
       desc: "",
+      pendingUpdate: false,
+      hotplugEnabled: false,
     },
   ],
   fns: [],
@@ -40,6 +44,7 @@ const state = (over: Partial<StateData> = {}): StateData => ({
 beforeEach(() => {
   vi.mocked(fetchState).mockClear();
   vi.mocked(fetchState).mockResolvedValue(state());
+  vi.mocked(setModuleHotplug).mockResolvedValue(undefined);
 });
 
 describe("ModulesSection", () => {
@@ -77,6 +82,8 @@ describe("ModulesSection", () => {
             zygisk: true,
             disabled: false,
             desc: "",
+            pendingUpdate: false,
+            hotplugEnabled: false,
           },
         ],
       }),
@@ -99,6 +106,8 @@ describe("ModulesSection", () => {
             zygisk: false,
             disabled: false,
             desc: "",
+            pendingUpdate: false,
+            hotplugEnabled: false,
           },
         ],
       }),
@@ -115,6 +124,37 @@ describe("ModulesSection", () => {
     const wrapper = mount(ModulesSection);
     await flushPromises();
     expect(wrapper.text()).toContain("No Zygisk modules installed");
+    wrapper.unmount();
+  });
+
+  it("shows a hotplug switch instead of the status text for a pending update, and toggles it", async () => {
+    vi.mocked(fetchState).mockResolvedValue(
+      state({
+        modules: [
+          {
+            id: "playintegrityfix",
+            name: "Play Integrity Fix",
+            version: "v18.8",
+            author: "chiteroman",
+            zygisk: true,
+            disabled: false,
+            desc: "",
+            pendingUpdate: true,
+            hotplugEnabled: false,
+          },
+        ],
+      }),
+    );
+    const wrapper = mount(ModulesSection);
+    await flushPromises();
+
+    expect(wrapper.find(".mod-row__status").exists()).toBe(false);
+    const toggle = wrapper.find(".mod-row__hotplug input[type=checkbox]");
+    expect((toggle.element as HTMLInputElement).checked).toBe(false);
+
+    await toggle.setValue(true);
+    await flushPromises();
+    expect(setModuleHotplug).toHaveBeenCalledWith("playintegrityfix", true);
     wrapper.unmount();
   });
 });

--- a/zygiskd/webui/src/components/ModulesSection.vue
+++ b/zygiskd/webui/src/components/ModulesSection.vue
@@ -1,18 +1,32 @@
 <script setup lang="ts">
-import { computed, inject } from "vue";
-import { fmtVer } from "../api/system";
+import { computed, inject, ref } from "vue";
+import { fmtVer, setModuleHotplug } from "../api/system";
 import { useLocale } from "../composables/useLocale";
 import { MONITOR_STATE_KEY, useMonitorState } from "../composables/useMonitorState";
 import type { MonitorState } from "../composables/useMonitorState";
 import Card from "./atoms/Card.vue";
+import Switch from "./atoms/Switch.vue";
+import type { ModuleInfo } from "../types";
 
 const { t } = useLocale();
 // Shared 6s-polled state (provided by App.vue); local fallback for standalone mounts.
 const state = inject<MonitorState | null>(MONITOR_STATE_KEY, null) ?? useMonitorState();
-const { loading, error, modules } = state;
+const { loading, error, modules, load } = state;
 
 // Only Zygisk-capable modules are shown (the shell also filters them).
 const zygiskModules = computed(() => modules.value.filter((m) => m.zygisk));
+
+const msg = ref("");
+
+async function toggleHotplug(m: ModuleInfo, enabled: boolean) {
+  msg.value = "";
+  try {
+    await setModuleHotplug(m.id, enabled);
+    await load();
+  } catch (e) {
+    msg.value = e instanceof Error ? e.message : String(e);
+  }
+}
 </script>
 
 <template>
@@ -27,15 +41,26 @@ const zygiskModules = computed(() => modules.value.filter((m) => m.zygisk));
             <span class="mod-row__name">{{ m.name || m.id }}</span>
             <span class="mod-row__ver">{{ fmtVer(m.version) }}</span>
           </div>
-          <div v-if="m.desc" class="mod-row__desc">{{ m.desc }}</div>
+          <div class="mod-row__meta">
+            <span v-if="m.desc" class="mod-row__desc">{{ m.desc }}</span>
+            <span v-if="m.pendingUpdate" class="mod-row__pending">{{ t("modules.pendingUpdate") }}</span>
+          </div>
           <div class="mod-row__foot">
             <span class="mod-row__author">{{ m.author || t("modules.unknownAuthor") }}</span>
-            <span class="mod-row__status" :class="m.disabled ? 'off' : 'on'">
+            <div v-if="m.pendingUpdate" class="mod-row__hotplug">
+              <span class="mod-row__hotplug-label">{{ t("modules.hotplug") }}</span>
+              <Switch
+                :checked="m.hotplugEnabled"
+                @update:checked="toggleHotplug(m, $event)"
+              />
+            </div>
+            <span v-else class="mod-row__status" :class="m.disabled ? 'off' : 'on'">
               {{ m.disabled ? t("common.disabled") : t("common.enabled") }}
             </span>
           </div>
         </div>
       </div>
+      <div v-if="msg" class="msg">{{ msg }}</div>
     </Card>
   </section>
 </template>
@@ -54,10 +79,21 @@ const zygiskModules = computed(() => modules.value.filter((m) => m.zygisk));
   font-size: 12px;
   color: var(--text3);
 }
+.mod-row__meta {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 2px;
+}
 .mod-row__desc {
   font-size: 12px;
   color: var(--text2);
-  margin-top: 2px;
+}
+.mod-row__pending {
+  font-size: 11px;
+  color: var(--orange);
+  font-weight: 500;
 }
 .mod-row__foot {
   display: flex;
@@ -77,6 +113,15 @@ const zygiskModules = computed(() => modules.value.filter((m) => m.zygisk));
   color: var(--green);
 }
 .mod-row__status.off {
+  color: var(--text3);
+}
+.mod-row__hotplug {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.mod-row__hotplug-label {
+  font-size: 11px;
   color: var(--text3);
 }
 </style>

--- a/zygiskd/webui/src/locales/en_US.json
+++ b/zygiskd/webui/src/locales/en_US.json
@@ -33,7 +33,9 @@
   "modules": {
     "hint": "Zygisk modules in /data/adb/modules",
     "empty": "No Zygisk modules installed",
-    "unknownAuthor": "unknown"
+    "unknownAuthor": "unknown",
+    "pendingUpdate": "Update staged, not yet applied",
+    "hotplug": "Apply now"
   },
   "fn": {
     "hint": "FN nodes in /data/adb/onyxzygisk/fn",

--- a/zygiskd/webui/src/locales/ja_JP.json
+++ b/zygiskd/webui/src/locales/ja_JP.json
@@ -33,7 +33,9 @@
   "modules": {
     "hint": "/data/adb/modules 内の Zygisk モジュール",
     "empty": "インストール済みの Zygisk モジュールがありません",
-    "unknownAuthor": "不明"
+    "unknownAuthor": "不明",
+    "pendingUpdate": "更新が保留中です",
+    "hotplug": "今すぐ適用"
   },
   "fn": {
     "hint": "FN ノードは /data/adb/onyxzygisk/fn にあります",

--- a/zygiskd/webui/src/locales/zh_CN.json
+++ b/zygiskd/webui/src/locales/zh_CN.json
@@ -33,7 +33,9 @@
   "modules": {
     "hint": "位于 /data/adb/modules 的 Zygisk 模块",
     "empty": "没有已安装的 Zygisk 模块",
-    "unknownAuthor": "未知作者"
+    "unknownAuthor": "未知作者",
+    "pendingUpdate": "有更新待生效",
+    "hotplug": "立即生效"
   },
   "fn": {
     "hint": "FN 节点位于 /data/adb/onyxzygisk/fn",

--- a/zygiskd/webui/src/types.ts
+++ b/zygiskd/webui/src/types.ts
@@ -21,7 +21,7 @@ export interface StatusKeys {
   [key: string]: string | undefined;
 }
 
-/** A Zygisk module row (the `M|id|name|version|author|zygisk|disabled|desc` record). */
+/** A Zygisk module row (the `M|id|name|version|author|zygisk|disabled|desc|pending|hotplug` record). */
 export interface ModuleInfo {
   id: string;
   name: string;
@@ -30,6 +30,12 @@ export interface ModuleInfo {
   zygisk: boolean;
   disabled: boolean;
   desc: string;
+  /** A newer version is staged (KernelSU/APatch), confirmed fully written,
+   * waiting for the next reboot's official swap into the active directory. */
+  pendingUpdate: boolean;
+  /** Whether the user opted in to the daemon using the staged version early,
+   * ahead of that reboot. Only meaningful when `pendingUpdate` is true. */
+  hotplugEnabled: boolean;
 }
 
 /** An FN node row (the `F|id|name|version|trigger|scope|status` record). */


### PR DESCRIPTION
#22 made the daemon prefer a staged module update automatically, the instant its "install finished" signal appeared. That's silent behavior — it reads a file the root solution itself hasn't officially committed yet, with zero user visibility into it happening. This adds the confirmation step: a per-module switch, right on that module's row in the WebUI, and the daemon now requires it before touching a staged update at all.

## Where the switch lives

Right where the module's "已启用/已禁用" (enabled/disabled) status text used to be — bottom-right of each row. When a pending update is detected, that spot becomes the switch instead; a small badge next to the description flags that an update is staged.

## Why this needed two separate implementations

The WebUI's module list runs its **own shell script** (`STATUS_SCRIPT` in `api/system.ts`), completely independent of the daemon's Unix socket protocol — it never talks to `zygiskd` for this data at all. So "is there a complete staged update for this module" had to be reimplemented in shell, using the exact same signals #22 established for the Rust side:

- KernelSU: `modules/<id>/update` exists
- APatch/FolkPatch (shares `apd`'s staging): the global `/data/adb/ap/update` exists **and** the module actually has a staged `.so`
- Magisk: never pending, same as the daemon

## The gate itself

`zygiskd.rs` gains `hotplug_opted_in()`, checking `WORKDIR/hotplug/<id>` — touched/removed by the WebUI switch exactly like the `disable`/`update`/`remove` flags elsewhere in this project. `eligible_modules()`'s staged-update overlay now requires **both** `staged_update_ready()` (the root solution says this is safe to read) **and** `hotplug_opted_in()` (the user said to use it early) — previously it only checked the former.

## Verification

Full NDK rebuild (zero warnings), `vue-tsc --noEmit` clean, 46/46 WebUI tests passing — including new coverage for the switch appearing on a pending module, replacing the status text, and calling through on toggle.
