### PR TITLE
feat(daemon): fix hot-plug readiness and add a master switch (WebUI)

### DIFF
--- a/zygiskd/src/zygiskd.rs
+++ b/zygiskd/src/zygiskd.rs
@@ -256,31 +256,22 @@ fn get_arch() -> Result<&'static str> {
 }
 
 /// Whether a staged update for `name` sitting in `PATH_MODULES_UPDATE_DIR` is
-/// guaranteed complete and safe to read, per the active root solution's own
-/// "install/update finished" signal — the exact signal it uses internally
-/// before swapping the staged copy into the active module directory at the
-/// next boot (see `ksud`'s / `apd`'s own `handle_updated_modules`).
+/// complete and safe to read.
 ///
-/// KernelSU marks this per module: `modules/<id>/update` is the last file
-/// `ksud` writes when that module's install/update finishes, so its presence
-/// alone proves `modules_update/<id>/` is fully written.
+/// The root solutions' own "install/update finished" flags are not reliable
+/// across KernelSU / APatch / FolkPatch in practice: ksud only leaves a
+/// metadata stub in `modules/<id>/` (no `.so`) and apd's global
+/// `/data/adb/ap/update` flag is cleared at boot. So file completeness of the
+/// staged entry itself is the signal — `module.prop` plus at least one ABI's
+/// Zygisk `.so`, the exact payload this daemon needs to serve the module.
 ///
-/// APatch marks it with one global flag instead (`apd`'s `mark_update`, also
-/// written last): once it exists, every entry currently in
-/// `modules_update/` already finished its own (synchronous) install,
-/// regardless of which one triggered the flag.
-///
-/// Magisk has no equivalent per-module signal found, so this is always false
-/// there — a fresh or updated module still needs a reboot before this daemon
-/// can see it.
-fn staged_update_ready(root: root_impl::RootImpl, name: &str) -> bool {
-    match root {
-        root_impl::RootImpl::KernelSU => {
-            Path::new(constants::PATH_MODULES_DIR).join(name).join("update").exists()
-        }
-        root_impl::RootImpl::APatch => Path::new(constants::PATH_APATCH_UPDATE_FLAG).exists(),
-        _ => false,
-    }
+/// Magisk has no staging directory at all, so this is always false there — a
+/// fresh or updated module still needs a reboot before this daemon can see it.
+fn staged_update_ready(name: &str) -> bool {
+    let dir = Path::new(constants::PATH_MODULES_UPDATE_DIR).join(name);
+    dir.join("module.prop").exists()
+        && (dir.join("zygisk/arm64-v8a.so").exists()
+            || dir.join("zygisk/armeabi-v7a.so").exists())
 }
 
 /// Whether the user explicitly opted `name` into using its staged update
@@ -296,22 +287,34 @@ fn hotplug_opted_in(name: &str) -> bool {
     Path::new(TMP_PATH.get().unwrap()).join("hotplug").join(name).exists()
 }
 
+/// Master switch for the whole hot-plug feature (`WORKDIR/hotplug_off`
+/// present). When off, every per-module opt-in is ignored and staged updates
+/// only take effect through the root solution's own boot-time swap — i.e. a
+/// reboot. Absent by default, so hot-plug is on out of the box.
+fn hotplug_master_enabled() -> bool {
+    !Path::new(TMP_PATH.get().unwrap()).join("hotplug_off").exists()
+}
+
 /// Names and directories of every module eligible for Zygisk injection,
 /// sorted by name. Two sources are merged:
 ///
 /// - `PATH_MODULES_DIR`, the active directory — today's baseline;
-/// - for KernelSU and APatch, any module with a *complete* staged update in
-///   `PATH_MODULES_UPDATE_DIR` that the user has also explicitly opted into
-///   (see `staged_update_ready` and `hotplug_opted_in`). A staged entry wins
-///   over an active one with the same name (it is the newer version); its
-///   disabled state is inherited from the active entry, mirroring exactly
-///   what `ksud`'s / `apd`'s own boot-time swap does ("if the old module is
-///   disabled, the new one starts disabled too").
+/// - any module with a *complete* staged update in `PATH_MODULES_UPDATE_DIR`
+///   that the user has also explicitly opted into, while the hot-plug master
+///   switch is on (see `staged_update_ready`, `hotplug_master_enabled` and
+///   `hotplug_opted_in`). A staged entry wins over an active one with the
+///   same name (it is the newer version); its disabled state is inherited
+///   from the active entry, mirroring exactly what `ksud`'s / `apd`'s own
+///   boot-time swap does ("if the old module is disabled, the new one starts
+///   disabled too").
 ///
 /// This is what lets a freshly installed or updated module become
 /// injectable on the very next process fork, instead of waiting for the
 /// boot-time swap the root solution itself performs — once the user
 /// confirms it, via the WebUI's per-module switch.
+///
+/// Hot-plug is inherently Zygisk-only: both sources only accept entries that
+/// carry `zygisk/<arch>.so` for the running ABI.
 ///
 /// Sorting keeps the order deterministic across the several independent
 /// re-scans a single process specialize can trigger (`ReadModules`, then
@@ -335,11 +338,11 @@ fn eligible_modules(arch: &str) -> Vec<(String, PathBuf)> {
         warn!("Failed to read modules directory: {}", constants::PATH_MODULES_DIR);
     }
 
-    let root = root_impl::get();
     if let Ok(dir) = fs::read_dir(constants::PATH_MODULES_UPDATE_DIR) {
         for entry in dir.flatten() {
             let name = entry.file_name().into_string().unwrap_or_default();
-            if !staged_update_ready(*root, &name) || !hotplug_opted_in(&name) {
+            if !hotplug_master_enabled() || !staged_update_ready(&name) || !hotplug_opted_in(&name)
+            {
                 continue;
             }
             let module_dir = entry.path();

--- a/zygiskd/webui/src/api/system.ts
+++ b/zygiskd/webui/src/api/system.ts
@@ -28,36 +28,53 @@ const STATUS_SCRIPT = [
   // stopped. Match all three names.
   'echo "daemon=$(pidof zygiskd zygiskd64 zygiskd32 >/dev/null 2>&1 && echo 1 || echo 0)"',
   'echo "workdir=$W"',
+  // Hot-plug master switch: off (WORKDIR/hotplug_off present) means staged
+  // updates only apply at the root solution's own boot-time swap.
+  'echo "hotplug=$([ -f "$W/hotplug_off" ] && echo 0 || echo 1)"',
   'echo "@@monitor"',
   'cat "$W/module.prop" 2>/dev/null | head -c 600; echo',
   'echo "@@modules"',
-  "for d in /data/adb/modules/*/; do",
-  '  [ -d "$d" ] || continue; p="$d/module.prop"; [ -f "$p" ] || continue',
-  '  id=$(sed -n "s/^id=//p" "$p" | head -n1)',
-  '  nm=$(sed -n "s/^name=//p" "$p" | head -n1)',
-  '  ver=$(sed -n "s/^version=//p" "$p" | head -n1)',
-  '  au=$(sed -n "s/^author=//p" "$p" | head -n1)',
-  '  ds=$(sed -n "s/^description=//p" "$p" | head -n1)',
-  '  zy=0; [ -f "$d/zygisk/arm64-v8a.so" ] || [ -f "$d/zygisk/armeabi-v7a.so" ] && zy=1',
-  '  dis=0; [ -f "$d/disable" ] && dis=1',
+  // Collect module ids from BOTH the active directory and the staging
+  // directory, deduplicated. A genuinely new install lives only in
+  // modules_update/ until the next reboot: KernelSU leaves a metadata-only
+  // stub in modules/<id>/ with no .so, APatch leaves modules/<id>/ empty — so
+  // iterating the active directory alone hides new installs entirely, and
+  // then their hotplug switch can never appear. `id` is the directory
+  // basename, matching how the daemon keys modules (and names the hotplug
+  // flag; see zygiskd::eligible_modules / hotplug_opted_in).
+  '  mids=""',
+  "  for d in /data/adb/modules/*/ /data/adb/modules_update/*/; do",
+  '    [ -d "$d" ] || continue',
+  '    bn=${d%/}; bn=${bn##*/}',
+  '    case " $mids " in *" $bn "*) ;; *) mids="$mids $bn" ;; esac',
+  "  done",
+  "  for id in $mids; do",
+  '    ad="/data/adb/modules/$id"; ud="/data/adb/modules_update/$id"',
+  // Is a *complete* staged update present for this id? Same signal the daemon
+  // uses (zygiskd::staged_update_ready): module.prop plus at least one ABI's
+  // Zygisk .so. The root solutions' own "update" flags are not reliable in
+  // practice (ksud leaves only a metadata stub in modules/<id>, apd's global
+  // flag is cleared at boot), so file completeness is the signal.
+  '    pend=0',
+  '    [ -f "$ud/module.prop" ] && { [ -f "$ud/zygisk/arm64-v8a.so" ] || [ -f "$ud/zygisk/armeabi-v7a.so" ]; } && pend=1',
+  // Read metadata + the .so from the staged copy when a staged update is
+  // present (it is the version that will run once applied), else the active
+  // copy. `dis` always comes from the active dir — the disable flag lives
+  // there and the daemon inherits it across the swap.
+  '    msrc="$ad"; [ "$pend" = 1 ] && [ -f "$ud/module.prop" ] && msrc="$ud"',
+  '    zsrc="$ad"; [ "$pend" = 1 ] && { [ -f "$ud/zygisk/arm64-v8a.so" ] || [ -f "$ud/zygisk/armeabi-v7a.so" ]; } && zsrc="$ud"',
+  '    p="$msrc/module.prop"; [ -f "$p" ] || continue',
+  '    zy=0; { [ -f "$zsrc/zygisk/arm64-v8a.so" ] || [ -f "$zsrc/zygisk/armeabi-v7a.so" ]; } && zy=1',
   // Only Zygisk-capable modules are shown in the WebUI.
-  '  [ "$zy" = 0 ] && continue',
-  // A newer version staged by the root manager (KernelSU/APatch), confirmed
-  // fully written by that root solution's own "install finished" signal —
-  // same check the daemon itself uses, see zygiskd::staged_update_ready.
-  // FolkPatch reuses APatch's apd and its staging convention.
-  '  pend=0',
-  '  if [ "$r" = "KernelSU" ]; then',
-  '    [ -f "/data/adb/modules/$id/update" ] && pend=1',
-  '  elif [ "$r" = "APatch" ] || [ "$r" = "FolkPatch" ]; then',
-  '    if [ -f "/data/adb/ap/update" ]; then',
-  '      [ -f "/data/adb/modules_update/$id/zygisk/arm64-v8a.so" ] && pend=1',
-  '      [ -f "/data/adb/modules_update/$id/zygisk/armeabi-v7a.so" ] && pend=1',
-  '    fi',
-  '  fi',
-  '  hp=0; [ -f "$W/hotplug/$id" ] && hp=1',
-  '  echo "M|$id|$nm|$ver|$au|$zy|$dis|$ds|$pend|$hp"',
-  "done",
+  '    [ "$zy" = 0 ] && continue',
+  '    nm=$(sed -n "s/^name=//p" "$p" | head -n1)',
+  '    ver=$(sed -n "s/^version=//p" "$p" | head -n1)',
+  '    au=$(sed -n "s/^author=//p" "$p" | head -n1)',
+  '    ds=$(sed -n "s/^description=//p" "$p" | head -n1)',
+  '    dis=0; [ -f "$ad/disable" ] && dis=1',
+  '    hp=0; [ -f "$W/hotplug/$id" ] && hp=1',
+  '    echo "M|$id|$nm|$ver|$au|$zy|$dis|$ds|$pend|$hp"',
+  "  done",
   'echo "@@fn"',
   'for d in "$W"/fn/*/; do',
   '  [ -d "$d" ] || continue; p="$d/fn.prop"; [ -f "$p" ] || continue',
@@ -162,13 +179,21 @@ export async function setFnEnabled(id: string, enabled: boolean): Promise<void> 
 }
 
 /** Opt a module with a detected pending update into using it immediately —
- * the daemon only overlays a staged update when both this flag and the root
- * solution's own "install finished" signal are present. See
- * zygiskd::eligible_modules. */
+ * the daemon only overlays a staged update when both this flag and the
+ * hot-plug master switch are on. See zygiskd::eligible_modules. */
 export async function setModuleHotplug(id: string, enabled: boolean): Promise<void> {
   const dir = `${WORKDIR}/hotplug`;
   const flag = `${dir}/${id}`;
   await exec(enabled ? `mkdir -p '${dir}' && touch '${flag}'` : `rm -f '${flag}'`);
+}
+
+/** Master switch for the hot-plug feature. When off, per-module opt-ins are
+ * ignored and staged updates only apply at the root solution's boot-time
+ * swap (a reboot). Flag file: WORKDIR/hotplug_off, absent = enabled.
+ * See zygiskd::hotplug_master_enabled. */
+export async function setHotplugMaster(enabled: boolean): Promise<void> {
+  const flag = `${WORKDIR}/hotplug_off`;
+  await exec(enabled ? `rm -f '${flag}'` : `touch '${flag}'`);
 }
 
 /** Normalize version display: strip a leading v/V then add one. */

--- a/zygiskd/webui/src/components/ModulesSection.vue
+++ b/zygiskd/webui/src/components/ModulesSection.vue
@@ -11,7 +11,7 @@ import type { ModuleInfo } from "../types";
 const { t } = useLocale();
 // Shared 6s-polled state (provided by App.vue); local fallback for standalone mounts.
 const state = inject<MonitorState | null>(MONITOR_STATE_KEY, null) ?? useMonitorState();
-const { loading, error, modules, load } = state;
+const { loading, error, modules, hotplug, load } = state;
 
 // Only Zygisk-capable modules are shown (the shell also filters them).
 const zygiskModules = computed(() => modules.value.filter((m) => m.zygisk));
@@ -48,9 +48,13 @@ async function toggleHotplug(m: ModuleInfo, enabled: boolean) {
           <div class="mod-row__foot">
             <span class="mod-row__author">{{ m.author || t("modules.unknownAuthor") }}</span>
             <div v-if="m.pendingUpdate" class="mod-row__hotplug">
-              <span class="mod-row__hotplug-label">{{ t("modules.hotplug") }}</span>
+              <span class="mod-row__hotplug-label">
+                {{ t("modules.hotplug") }}
+                <span v-if="!hotplug" class="mod-row__hotplug-off">{{ t("modules.hotplugOff") }}</span>
+              </span>
               <Switch
                 :checked="m.hotplugEnabled"
+                :disabled="!hotplug"
                 @update:checked="toggleHotplug(m, $event)"
               />
             </div>
@@ -123,5 +127,11 @@ async function toggleHotplug(m: ModuleInfo, enabled: boolean) {
 .mod-row__hotplug-label {
   font-size: 11px;
   color: var(--text3);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.mod-row__hotplug-off {
+  color: var(--orange);
 }
 </style>

--- a/zygiskd/webui/src/components/SettingsSection.vue
+++ b/zygiskd/webui/src/components/SettingsSection.vue
@@ -1,16 +1,24 @@
 <script setup lang="ts">
-/* Settings section — theme + language. */
-import { ref } from "vue";
+/* Settings section — theme, language, hot-plug master switch. */
+import { inject, ref } from "vue";
+import { setHotplugMaster } from "../api/system";
 import { useLocale } from "../composables/useLocale";
 import { AUTO_LOCALE } from "../composables/useLocale";
 import type { LocalePref } from "../composables/useLocale";
 import { THEMES, applyTheme, getThemePref, setThemePref } from "../composables/useTheme";
 import type { ThemePref } from "../composables/useTheme";
+import { MONITOR_STATE_KEY, useMonitorState } from "../composables/useMonitorState";
+import type { MonitorState } from "../composables/useMonitorState";
 import Card from "./atoms/Card.vue";
+import Switch from "./atoms/Switch.vue";
 
 const { t, locale, setLocale, availableLocales } = useLocale();
 
 const theme = ref<ThemePref>(getThemePref());
+
+// Shared 6s-polled state (provided by App.vue); local fallback for standalone.
+const state = inject<MonitorState | null>(MONITOR_STATE_KEY, null) ?? useMonitorState();
+const { hotplug, load } = state;
 
 function cap(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
@@ -25,6 +33,15 @@ function onTheme(e: Event): void {
 
 function onLang(e: Event): void {
   setLocale((e.target as HTMLSelectElement).value as LocalePref);
+}
+
+async function toggleHotplug(enabled: boolean): Promise<void> {
+  try {
+    await setHotplugMaster(enabled);
+    await load();
+  } catch (e) {
+    /* the next poll re-syncs the switch state */
+  }
 }
 </script>
 
@@ -48,6 +65,13 @@ function onLang(e: Event): void {
           </option>
         </select>
       </div>
+      <div class="setting-row">
+        <span class="s-label">
+          {{ t("settings.hotplug") }}
+          <span class="hint">{{ t("settings.hotplugHint") }}</span>
+        </span>
+        <Switch :checked="hotplug" @update:checked="toggleHotplug" />
+      </div>
     </Card>
 
     <!-- <Card :title="t('settings.about')">
@@ -69,5 +93,11 @@ function onLang(e: Event): void {
 }
 .setting-row .s-label {
   font-size: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.setting-row .hint {
+  font-size: 11px;
 }
 </style>

--- a/zygiskd/webui/src/components/atoms/Switch.vue
+++ b/zygiskd/webui/src/components/atoms/Switch.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 /* Switch — pill toggle (.switch). Bound with v-model:checked. */
 const checked = defineModel<boolean>("checked", { default: false });
+defineProps<{ disabled?: boolean }>();
 </script>
 
 <template>
-  <label class="switch">
-    <input type="checkbox" v-model="checked" />
+  <label class="switch" :class="{ 'switch--disabled': disabled }">
+    <input type="checkbox" v-model="checked" :disabled="disabled" />
     <span class="slider"></span>
   </label>
 </template>

--- a/zygiskd/webui/src/composables/useMonitorState.ts
+++ b/zygiskd/webui/src/composables/useMonitorState.ts
@@ -22,6 +22,7 @@ export interface MonitorState {
   fns: Ref<FnNodeInfo[]>;
   rootImpl: Ref<string>;
   version: Ref<string>;
+  hotplug: Ref<boolean>;
   load: () => Promise<void>;
 }
 
@@ -33,6 +34,7 @@ export function useMonitorState(): MonitorState {
   const fns = ref<FnNodeInfo[]>([]);
   const rootImpl = ref("");
   const version = ref("");
+  const hotplug = ref(true);
   const { locale } = useLocale();
 
   let timer: number | undefined;
@@ -42,6 +44,7 @@ export function useMonitorState(): MonitorState {
       const d = await fetchState();
       rootImpl.value = d.keys.root || "";
       version.value = d.keys.version || "";
+      hotplug.value = d.keys.hotplug !== "0";
       monitor.value = parseMonitor(d.monitor);
       modules.value = d.modules;
       fns.value = d.fns;
@@ -61,5 +64,5 @@ export function useMonitorState(): MonitorState {
   // Reload on language switch (dev mock data follows the locale).
   watch(locale, () => load());
 
-  return { loading, error, monitor, modules, fns, rootImpl, version, load };
+  return { loading, error, monitor, modules, fns, rootImpl, version, hotplug, load };
 }

--- a/zygiskd/webui/src/locales/en_US.json
+++ b/zygiskd/webui/src/locales/en_US.json
@@ -35,7 +35,8 @@
     "empty": "No Zygisk modules installed",
     "unknownAuthor": "unknown",
     "pendingUpdate": "Update staged, not yet applied",
-    "hotplug": "Apply now"
+    "hotplug": "Apply now",
+    "hotplugOff": "master off"
   },
   "fn": {
     "hint": "FN nodes in /data/adb/onyxzygisk/fn",
@@ -64,6 +65,8 @@
     "language": "Language",
     "languageAuto": "Auto",
     "about": "About",
-    "aboutText": "OnyxZygisk — a Zygisk implementation via ptrace, with FN (Functional Node) modules. Fork of NeoZygisk."
+    "aboutText": "OnyxZygisk — a Zygisk implementation via ptrace, with FN (Functional Node) modules. Fork of NeoZygisk.",
+    "hotplug": "Hot-plug (Zygisk Host)",
+    "hotplugHint": "When off, modules take effect only after a reboot"
   }
 }

--- a/zygiskd/webui/src/locales/ja_JP.json
+++ b/zygiskd/webui/src/locales/ja_JP.json
@@ -35,7 +35,8 @@
     "empty": "インストール済みの Zygisk モジュールがありません",
     "unknownAuthor": "不明",
     "pendingUpdate": "更新が保留中です",
-    "hotplug": "今すぐ適用"
+    "hotplug": "今すぐ適用",
+    "hotplugOff": "無効"
   },
   "fn": {
     "hint": "FN ノードは /data/adb/onyxzygisk/fn にあります",
@@ -64,6 +65,8 @@
     "language": "言語",
     "languageAuto": "自動",
     "about": "このモジュールについて",
-    "aboutText": "OnyxZygisk — ptrace ベースの Zygisk 実装で、FN（Functional Node）モジュールに対応しています。NeoZygisk のフォークです。"
+    "aboutText": "OnyxZygisk — ptrace ベースの Zygisk 実装で、FN（Functional Node）モジュールに対応しています。NeoZygisk のフォークです。",
+    "hotplug": "ホットプラグ（Zygisk Host）",
+    "hotplugHint": "オフの間は再起動後にのみ有効"
   }
 }

--- a/zygiskd/webui/src/locales/zh_CN.json
+++ b/zygiskd/webui/src/locales/zh_CN.json
@@ -35,7 +35,8 @@
     "empty": "没有已安装的 Zygisk 模块",
     "unknownAuthor": "未知作者",
     "pendingUpdate": "有更新待生效",
-    "hotplug": "立即生效"
+    "hotplug": "立即生效",
+    "hotplugOff": "已停用"
   },
   "fn": {
     "hint": "FN 节点位于 /data/adb/onyxzygisk/fn",
@@ -64,6 +65,8 @@
     "language": "语言",
     "languageAuto": "自动",
     "about": "关于",
-    "aboutText": "OnyxZygisk —— 基于 ptrace 的 Zygisk 实现，支持 FN（Functional Node）模块。fork 自 NeoZygisk。"
+    "aboutText": "OnyxZygisk —— 基于 ptrace 的 Zygisk 实现，支持 FN（Functional Node）模块。fork 自 NeoZygisk。",
+    "hotplug": "热插拔（Zygisk Host）",
+    "hotplugHint": "关闭后模块需重启才生效"
   }
 }

--- a/zygiskd/webui/src/styles/main.css
+++ b/zygiskd/webui/src/styles/main.css
@@ -552,6 +552,10 @@ select:focus {
 .switch input:checked + .slider::before {
   transform: translateX(18px);
 }
+.switch--disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
 
 /* ── misc ── */
 .empty {


### PR DESCRIPTION
修复热插拔无法正常使用 + 热插拔总开关。

## Bug
staged_update_ready 依赖 root 方案的 "update" 标记文件（ksud 只留 metadata stub、apd 全局标记开机即清）→ daemon 永远不服务 staged 模块 → **刷入后必须重启才生效**。

## 修复
- staged 就绪判定改为**文件完整性**：module.prop + zygisk/\<arch\>.so（daemon 需要的正是这个载荷），不再依赖 root 标记
- 热插拔总开关：`WORKDIR/hotplug_off`（缺省=开）；关闭后 per-module 开关全部失效，staged 更新只随 root 方案开机交换生效
- 设置页新增总开关行；模块页 per-module "立即生效" 开关在总开关关闭时置灰
- 模块扫描：staged 存在时从 modules_update 读元数据/.so，pend 检测同样按完整性
- Switch 组件支持 disabled

热插拔仅限 Zygisk 模块（两处来源都要求 zygisk/\<arch\>.so）。
验证：vitest 46/46、WSL shell 逻辑、完整构建。