### PR TITLE
feat(webui): restart the zygote once when hot-plugging a module

### DIFF
--- a/zygiskd/webui/src/api/system.ts
+++ b/zygiskd/webui/src/api/system.ts
@@ -196,6 +196,14 @@ export async function setHotplugMaster(enabled: boolean): Promise<void> {
   await exec(enabled ? `rm -f '${flag}'` : `touch '${flag}'`);
 }
 
+/** Restart the zygote once so already-running processes (and the manager
+ * itself) pick up a newly opted-in module — the standard Zygisk activation
+ * step: init respawns the zygote and every app restarts once. Without it,
+ * only processes forked after the opt-in would see the module. */
+export async function restartZygote(): Promise<void> {
+  await exec("kill $(pidof zygote64 zygote zygote_secondary) 2>/dev/null; true");
+}
+
 /** Normalize version display: strip a leading v/V then add one. */
 export function fmtVer(v: string | undefined): string {
   const s = String(v || "?")

--- a/zygiskd/webui/src/components/ModulesSection.vue
+++ b/zygiskd/webui/src/components/ModulesSection.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, inject, ref } from "vue";
-import { fmtVer, setModuleHotplug } from "../api/system";
+import { fmtVer, restartZygote, setModuleHotplug } from "../api/system";
 import { useLocale } from "../composables/useLocale";
 import { MONITOR_STATE_KEY, useMonitorState } from "../composables/useMonitorState";
 import type { MonitorState } from "../composables/useMonitorState";
@@ -22,6 +22,12 @@ async function toggleHotplug(m: ModuleInfo, enabled: boolean) {
   msg.value = "";
   try {
     await setModuleHotplug(m.id, enabled);
+    if (enabled) {
+      // Standard Zygisk activation: restart the zygote once so the module
+      // takes effect in every (new) process without a device reboot.
+      await restartZygote();
+      msg.value = t("modules.hotplugRestarting");
+    }
     await load();
   } catch (e) {
     msg.value = e instanceof Error ? e.message : String(e);

--- a/zygiskd/webui/src/locales/en_US.json
+++ b/zygiskd/webui/src/locales/en_US.json
@@ -36,7 +36,8 @@
     "unknownAuthor": "unknown",
     "pendingUpdate": "Update staged, not yet applied",
     "hotplug": "Apply now",
-    "hotplugOff": "master off"
+    "hotplugOff": "master off",
+    "hotplugRestarting": "Enabled, restarting zygote…"
   },
   "fn": {
     "hint": "FN nodes in /data/adb/onyxzygisk/fn",

--- a/zygiskd/webui/src/locales/ja_JP.json
+++ b/zygiskd/webui/src/locales/ja_JP.json
@@ -36,7 +36,8 @@
     "unknownAuthor": "不明",
     "pendingUpdate": "更新が保留中です",
     "hotplug": "今すぐ適用",
-    "hotplugOff": "無効"
+    "hotplugOff": "無効",
+    "hotplugRestarting": "有効化しました、Zygote を再起動中…"
   },
   "fn": {
     "hint": "FN ノードは /data/adb/onyxzygisk/fn にあります",

--- a/zygiskd/webui/src/locales/zh_CN.json
+++ b/zygiskd/webui/src/locales/zh_CN.json
@@ -36,7 +36,8 @@
     "unknownAuthor": "未知作者",
     "pendingUpdate": "有更新待生效",
     "hotplug": "立即生效",
-    "hotplugOff": "已停用"
+    "hotplugOff": "已停用",
+    "hotplugRestarting": "已启用，正在重启 Zygote…"
   },
   "fn": {
     "hint": "FN 节点位于 /data/adb/onyxzygisk/fn",


### PR DESCRIPTION
热插拔开关勾选后自动重启一次 Zygote。

问题：勾选"立即生效"后只有新 fork 的进程能看到模块，已运行进程和管理器看不到 → 表现为"没效果"。

修复：勾选后 kill zygote 一次（init 自动重启，所有应用重新孵化一次）—— 与 Magisk/KSU 装完模块的标准激活行为一致，无需重启设备。模块行显示"正在重启 Zygote…"提示。