### PR TITLE
fix(daemon): stop depending on the one-shot SystemServerStarted event for service.sh readiness

### DIFF
--- a/zygiskd/src/zygiskd.rs
+++ b/zygiskd/src/zygiskd.rs
@@ -62,9 +62,8 @@ struct AppContext {
 // Global paths, initialized once at startup.
 static TMP_PATH: OnceLock<String> = OnceLock::new();
 
-/// Set once system_server has started (late boot). `service.sh`-stage
-/// daemons (lspd etc.) must not run before this — they crash on an
-/// unprepared framework (lspd dies with SIGSEGV during early boot).
+/// Sticky cache for `system_server_ready()`: sets once the property check
+/// first observes boot complete, so later calls skip the property read.
 static SYSTEM_SERVER_UP: AtomicBool = AtomicBool::new(false);
 static CONTROLLER_SOCKET: OnceLock<String> = OnceLock::new();
 static DAEMON_SOCKET_PATH: OnceLock<String> = OnceLock::new();
@@ -399,6 +398,12 @@ fn load_modules() -> Result<Vec<Module>> {
     let arch = get_arch()?;
     debug!("Daemon architecture: {arch}");
 
+    // Opportunistic catch-up: schedules any hot-plugged module's service.sh
+    // that missed the live SystemServerStarted event for this daemon
+    // instance (see `system_server_ready`). Cheap no-op once nothing is
+    // pending.
+    run_pending_staged_services();
+
     let mut modules = Vec::new();
     for (name, module_dir) in eligible_modules(arch) {
         // A staged entry needs activation: swap into the active directory and
@@ -465,6 +470,35 @@ fn run_module_script(module_dir: &Path, script: &Path) {
     }
 }
 
+/// Whether system_server is up enough for `service.sh`-stage daemons (lspd
+/// etc.) to start safely — they crash on an unprepared framework.
+///
+/// Trusting only the one-shot `SystemServerStarted` socket message (sent by
+/// the loader exactly once, when zygote forks system_server) is not enough:
+/// if *this* daemon process started after that already happened in the
+/// current zygote lifetime, the message has already fired and will not fire
+/// again this boot, so a purely event-driven flag would stay false forever.
+/// That is the common case here — flashing a new OnyxZygisk build does not
+/// restart the already-running daemon, only a device reboot does, and this
+/// feature's whole point is working without one.
+///
+/// `sys.boot_completed` is a standard Android property, independent of any
+/// root solution, queryable at any time — checking it directly is
+/// self-healing regardless of when the daemon happened to start. Sticky
+/// once observed true: further calls skip the property read.
+fn system_server_ready() -> bool {
+    if SYSTEM_SERVER_UP.load(Ordering::Relaxed) {
+        return true;
+    }
+    let ready = utils::get_property("sys.boot_completed")
+        .map(|v| v.trim() == "1")
+        .unwrap_or(false);
+    if ready {
+        SYSTEM_SERVER_UP.store(true, Ordering::Relaxed);
+    }
+    ready
+}
+
 /// Activates a hot-plugged staged module: swaps it into the active
 /// directory and runs its lifecycle scripts exactly once.
 ///
@@ -478,9 +512,10 @@ fn run_module_script(module_dir: &Path, script: &Path) {
 ///
 /// - `post-fs-data.sh` runs immediately (marker
 ///   `WORKDIR/hotplug_activated/<name>.post_fs_data`);
-/// - `service.sh` waits for system_server (SYSTEM_SERVER_UP): immediate
-///   when hot-plugging mid-session, deferred to the SystemServerStarted
-///   handler during boot (marker `...service`).
+/// - `service.sh` waits for system_server (see `system_server_ready`):
+///   immediate when hot-plugging mid-session on an already-booted device,
+///   otherwise caught on the next `load_modules()` call or the
+///   `SystemServerStarted` event, whichever comes first (marker `...service`).
 ///
 /// After the swap the module is a normal active module: served from the
 /// active dir, and the root solution's next boot-time swap finds nothing
@@ -526,7 +561,7 @@ fn activate_staged_module(name: &str, module_dir: &Path) {
     let marker_svc = Path::new(TMP_PATH.get().unwrap())
         .join("hotplug_activated")
         .join(format!("{name}.service"));
-    if !marker_svc.exists() && SYSTEM_SERVER_UP.load(Ordering::Relaxed) {
+    if !marker_svc.exists() && system_server_ready() {
         let dir_clone = dir.clone();
         let marker_clone = marker_svc.clone();
         std::thread::spawn(move || {
@@ -563,12 +598,22 @@ fn opted_in_staged_modules() -> Vec<(String, PathBuf)> {
 }
 
 /// Runs the deferred `service.sh` of hot-plugged modules once system_server
-/// is up (late boot) — the same point Magisk/KernelSU run service.sh.
-/// After the swap the module lives in the active directory, so this walks
-/// the activation markers: names with a `.post_fs_data` marker but no
-/// `.service` marker yet, whose active dir carries a Zygisk `.so`.
+/// is ready (see `system_server_ready`) — the same point Magisk/KernelSU run
+/// service.sh. After the swap the module lives in the active directory, so
+/// this walks the activation markers: names with a `.post_fs_data` marker
+/// but no `.service` marker yet, whose active dir carries a Zygisk `.so`.
+///
+/// Called both from the live `SystemServerStarted` event and opportunistically
+/// from every `load_modules()` call, so a module activated on a daemon
+/// instance that never received that event (started after system_server was
+/// already up) still gets its service.sh scheduled on the very next app
+/// launch instead of never. Cheap to call liberally: a directory scan plus
+/// marker checks, and each module is scheduled for real work at most once
+/// (guarded by the marker file itself).
 fn run_pending_staged_services() {
-    SYSTEM_SERVER_UP.store(true, Ordering::Relaxed);
+    if !system_server_ready() {
+        return;
+    }
     let markers = Path::new(TMP_PATH.get().unwrap()).join("hotplug_activated");
     let Ok(dir) = fs::read_dir(&markers) else {
         return;


### PR DESCRIPTION
Device logs from a hot-plugged LSPosed install showed `hotplug_activated/<name>.post_fs_data` present but no matching `.service` marker: `lspd` (LSPosed's own daemon, started by `service.sh`) never ran, so the module looked "mounted but not actually working" even though the swap into the active directory (#28) succeeded correctly.

## Root cause

`SYSTEM_SERVER_UP` was only ever set `true` by the live `SystemServerStarted` socket message the loader sends — exactly once, at the moment zygote first forks system_server. That message fires once and never again this boot.

Flashing a new OnyxZygisk build never restarts the already-running daemon — only a device reboot does, and this whole hot-plug feature exists specifically to avoid needing one. So any daemon instance that happens to start *after* system_server already came up this boot would see `SYSTEM_SERVER_UP` as permanently `false`, with no mechanism to ever correct it — not a rare edge case, but close to the default outcome for exactly the workflow this feature is built for.

## Fix

`system_server_ready()` checks the standard `sys.boot_completed` Android property directly (independent of any root solution, queryable at any time) whenever `SYSTEM_SERVER_UP` isn't already known true, caching the result once observed. This makes readiness self-healing regardless of when the daemon happened to start, instead of depending on catching a transient message.

Also moved `run_pending_staged_services()` (the deferred-service sweep) out of being purely event-triggered — it now also runs opportunistically from every `load_modules()` call (i.e. every app launch), so a module that missed its window at activation time still gets `service.sh` scheduled on the very next launch instead of never.

## Verification

Full NDK rebuild across all four ABIs, zero warnings.
