### PR TITLE
fix(loader): start the hot-plug poller after specialize, not during it

### DIFF
--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -502,9 +502,25 @@ static void hotplug_poller(ZygiskContext *ctx, JavaVM *vm) {
 void ZygiskContext::server_specialize_pre() {
     run_modules_pre();
     zygiskd::SystemServerStarted();
+}
+
+void ZygiskContext::server_specialize_post() {
+    run_modules_post();
 
     // Start the hot-plug poller once (system_server only). No restart of any
     // kind is involved: the module is loaded into the running process.
+    //
+    // This MUST run in _post, not _pre. server_specialize_pre() executes in
+    // the freshly forked child *before* the original nativeForkSystemServer
+    // reaches SpecializeCommon -> selinux_android_setcontext -> setcon().
+    // setcon() (writing /proc/self/attr/current) is rejected by the kernel
+    // for any process with more than one thread — the reason zygote is
+    // single-threaded by design. Spawning the poller thread in _pre left the
+    // child multi-threaded during that transition, so setcon() failed and
+    // zygote aborted (JNI FatalError, "selinux_android_setcontext ... failed")
+    // on every boot with a module opted in — a deterministic bootloop. By
+    // _post the SELinux context transition is already done, so an extra
+    // thread is harmless.
     static std::atomic<bool> started{false};
     if (!started.exchange(true)) {
         JavaVM *vm = nullptr;
@@ -514,8 +530,6 @@ void ZygiskContext::server_specialize_pre() {
         }
     }
 }
-
-void ZygiskContext::server_specialize_post() { run_modules_post(); }
 
 // -----------------------------------------------------------------
 


### PR DESCRIPTION
Three consecutive builds — v349 (#30), v353 (#31), v354 (#32) — bootlooped with the **identical** crash: zygote SIGABRT at `Process uptime: 1s`, `JNI FatalError ... selinux_android_setcontext(1000, 1, "(null)", "(null)") failed` during `nativeForkSystemServer` → `SpecializeCommon`, `libzygisk.so` in the frame.

## Why the last three fixes did nothing

They were all in the **daemon** (`zygiskd`, Rust). This crash is entirely in the **loader** (`libzygisk.so`, C++) — a different binary. I was fixing the wrong component three times. The only *loader* change since the last known-good build (v345, which boots fine — confirmed from a rolled-back device log) was #29's system_server hot-plug poller.

## Root cause

`server_specialize_pre()` runs in the freshly-forked child (system_server), before the original `nativeForkSystemServer` reaches `SpecializeCommon` → `selinux_android_setcontext` → `setcon()`.

`setcon()` — writing `/proc/self/attr/current` — is **rejected by the kernel for any process with more than one thread**. That's precisely why zygote is single-threaded by design. #29 spawned the poller `std::thread` in `_pre`, leaving the child multi-threaded during the SELinux context transition, so `setcon()` failed and zygote aborted — deterministically, on every boot with a module opted in.

## Fix

Move the poller start from `server_specialize_pre()` to `server_specialize_post()`, which runs *after* the fork+specialize has completed `setcon()`. By then the context transition is done and an extra thread is harmless. The poller's behaviour is otherwise unchanged — only its start point moves past the single-thread-required window.

## Verification

Loader builds clean across all four ABIs. This is the first fix in this sequence that actually targets the crashing binary. Still needs on-device confirmation — flash with a recovery path ready.
