### PR TITLE
fix(loader): remove the in-system_server hot-plug poller (revert #29 loader change)

### DIFF
--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -9,10 +9,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <thread>
-
 #include <algorithm>
-#include <atomic>
 #include <string>
 #include <vector>
 
@@ -453,83 +450,12 @@ void ZygiskContext::app_specialize_post() {
     env->ReleaseStringUTFChars(args.app->nice_name, process);
 }
 
-/**
- * Hot-plug poller, running only inside system_server.
- *
- * Framework-level modules (LSPosed etc.) only take effect in system_server
- * itself, and the user forbids any zygote/system_server restart. So once per
- * poll interval we re-read the daemon's module list and load modules that
- * appeared since the last scan directly into the running system_server:
- * memfd-load + onLoad + preServerSpecialize (with fresh, safe args). App
- * processes already get hot-plugged modules on their next fork.
- */
-static void hotplug_poller(ZygiskContext *ctx, JavaVM *vm) {
-    std::vector<std::string> loaded;
-    for (;;) {
-        sleep(15);
-        auto ms = zygiskd::ReadModules();
-        if (ms.empty()) continue;
-
-        JNIEnv *penv = nullptr;
-        if (vm->GetEnv(reinterpret_cast<void **>(&penv), JNI_VERSION_1_6) != JNI_OK) {
-            // The poller thread has no JNI env yet; attach it (never detach —
-            // the env stays valid for the lifetime of the poller).
-            if (vm->AttachCurrentThread(&penv, nullptr) != JNI_OK) continue;
-        }
-
-        for (size_t i = 0; i < ms.size(); i++) {
-            auto &m = ms[i];
-            if (std::find(loaded.begin(), loaded.end(), m.name) != loaded.end()) continue;
-            if (LoadedModule lm = LoadModuleFromMemfd(m.memfd)) {
-                LOGI("hot-plug: loading module `%s` into system_server", m.name.c_str());
-                ctx->modules.emplace_back(static_cast<int>(i), lm.handle, lm.entry, lm.custom);
-                auto &mod = ctx->modules.back();
-                mod.onLoad(penv);
-                // preServerSpecialize with fresh args — the specialize-time
-                // argument struct is long gone. LSPosed-class modules only
-                // read the env; the values are sane defaults.
-                jint uid = 1000, gid = 1000, runtime_flags = 0;
-                jintArray gids = nullptr;
-                jlong caps = 0;
-                ServerSpecializeArgs_v1 args(uid, gid, gids, runtime_flags, caps, caps);
-                mod.preServerSpecialize(&args);
-                loaded.push_back(m.name);
-            }
-        }
-    }
-}
-
 void ZygiskContext::server_specialize_pre() {
     run_modules_pre();
     zygiskd::SystemServerStarted();
 }
 
-void ZygiskContext::server_specialize_post() {
-    run_modules_post();
-
-    // Start the hot-plug poller once (system_server only). No restart of any
-    // kind is involved: the module is loaded into the running process.
-    //
-    // This MUST run in _post, not _pre. server_specialize_pre() executes in
-    // the freshly forked child *before* the original nativeForkSystemServer
-    // reaches SpecializeCommon -> selinux_android_setcontext -> setcon().
-    // setcon() (writing /proc/self/attr/current) is rejected by the kernel
-    // for any process with more than one thread — the reason zygote is
-    // single-threaded by design. Spawning the poller thread in _pre left the
-    // child multi-threaded during that transition, so setcon() failed and
-    // zygote aborted (JNI FatalError, "selinux_android_setcontext ... failed")
-    // on every boot with a module opted in — a deterministic bootloop. By
-    // _post the SELinux context transition is already done, so an extra
-    // thread is harmless.
-    static std::atomic<bool> started{false};
-    if (!started.exchange(true)) {
-        JavaVM *vm = nullptr;
-        if (env->GetJavaVM(&vm) == JNI_OK && vm != nullptr) {
-            std::thread(hotplug_poller, this, vm).detach();
-            LOGI("hot-plug: system_server module poller started");
-        }
-    }
-}
+void ZygiskContext::server_specialize_post() { run_modules_post(); }
 
 // -----------------------------------------------------------------
 


### PR DESCRIPTION
Four consecutive builds bootlooped the device — v349, v353, v354, and v355 (which included #33's poller-move fix). The v355 device state confirms it still crash-loops with a module opted in, so #33's "thread-before-setcon" theory was wrong or incomplete, and that log bundle carried no `logcat.log` so I can't see the exact v355 crash.

## The one thing that's certain

`v345 boots fine`, and the **only** loader change between v345 and every crashing build is #29's system_server hot-plug poller (added in #29, repositioned in #33). Rather than keep guessing at a zygote-level crash I have no way to verify a fix for, this reverts the loader to that known-good behavior by removing the poller entirely. `git log c1a5e70..master -- loader/` confirms #29 and #33 are the only loader commits since v345.

## Consequence (the honest tradeoff)

Unchanged (daemon-side): a hot-plugged module still gets served, swapped into `/data/adb/modules/<id>`, and injected into newly-forked **app** processes without a reboot.

Removed: live injection into the already-running **system_server**. So a framework module that hooks system_server (LSPosed) needs **one reboot** for its system_server hook to take effect — because live-injecting into a running system_server is precisely what bootlooped the device four times. Stability over a feature I could not make safe without a device.

## Verification

Loader builds clean across all four ABIs. This restores the loader to the v345 boot path, which is the only version in this whole sequence confirmed to boot.
