### PR TITLE
feat(hotplug): zero-reboot live load into system_server via post-boot signal

### DIFF
--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -9,8 +9,13 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <csignal>
+
 #include <algorithm>
+#include <atomic>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <lsplt.hpp>
@@ -450,12 +455,98 @@ void ZygiskContext::app_specialize_post() {
     env->ReleaseStringUTFChars(args.app->nice_name, process);
 }
 
+// ── live hot-plug into the already-running system_server ──
+//
+// Framework modules (LSPosed) only take effect inside system_server, and the
+// goal is zero reboot. The hard constraint learned the painful way: a thread
+// must NOT exist inside system_server while it is being specialized — a
+// process with >1 thread cannot complete selinux_android_setcontext ->
+// setcon() during SpecializeCommon, which bootlooped every build that spawned
+// a thread in server_specialize_pre OR _post (v349–v355).
+//
+// So at specialize time we create no thread — we only ARM a realtime signal
+// handler (cheap, single-threaded, setcon-safe). The daemon sends that signal
+// only AFTER sys.boot_completed, i.e. long past the specialize window, when
+// system_server is fully up and already massively multi-threaded. The handler
+// then spawns a short-lived worker that pulls the current module list from the
+// daemon and loads any not-yet-loaded module into this live system_server.
+//
+// Signal 40 is a realtime signal (bionic reserves 32–34; 40 sits in the
+// user-available range) agreed with the daemon (see zygiskd's
+// signal_system_server_hotplug).
+static constexpr int kHotplugSignal = 40;
+static ZygiskContext *g_ss_ctx = nullptr;
+static JavaVM *g_ss_vm = nullptr;
+
+/// One pass: load every served module this system_server has not loaded yet.
+/// Runs on a worker thread spawned post-boot, never during specialize.
+static void hotplug_load_once() {
+    static std::mutex mtx;
+    static std::vector<std::string> loaded;
+    std::lock_guard<std::mutex> lk(mtx);
+
+    if (g_ss_ctx == nullptr || g_ss_vm == nullptr) return;
+    JNIEnv *penv = nullptr;
+    if (g_ss_vm->GetEnv(reinterpret_cast<void **>(&penv), JNI_VERSION_1_6) != JNI_OK) {
+        if (g_ss_vm->AttachCurrentThread(&penv, nullptr) != JNI_OK) return;
+    }
+
+    auto ms = zygiskd::ReadModules();
+    for (size_t i = 0; i < ms.size(); i++) {
+        auto &m = ms[i];
+        if (std::find(loaded.begin(), loaded.end(), m.name) != loaded.end()) continue;
+        if (LoadedModule lm = LoadModuleFromMemfd(m.memfd)) {
+            LOGI("hot-plug: loading module `%s` into live system_server", m.name.c_str());
+            g_ss_ctx->modules.emplace_back(static_cast<int>(i), lm.handle, lm.entry, lm.custom);
+            auto &mod = g_ss_ctx->modules.back();
+            mod.onLoad(penv);
+            // preServerSpecialize with fresh args — the specialize-time struct
+            // is long gone. LSPosed-class modules only read the env.
+            jint uid = 1000, gid = 1000, runtime_flags = 0;
+            jintArray gids = nullptr;
+            jlong caps = 0;
+            ServerSpecializeArgs_v1 args(uid, gid, gids, runtime_flags, caps, caps);
+            mod.preServerSpecialize(&args);
+            loaded.push_back(m.name);
+        }
+    }
+}
+
+/// Realtime-signal handler armed in system_server. Spawns the worker thread.
+/// Only ever runs post-boot (the daemon gates the signal on boot_completed),
+/// so creating a thread here is safe — the setcon single-thread requirement
+/// applies only during SpecializeCommon, which finished long ago.
+static void hotplug_signal_handler(int) {
+    if (g_ss_ctx != nullptr && g_ss_vm != nullptr) {
+        std::thread(hotplug_load_once).detach();
+    }
+}
+
 void ZygiskContext::server_specialize_pre() {
     run_modules_pre();
     zygiskd::SystemServerStarted();
 }
 
-void ZygiskContext::server_specialize_post() { run_modules_post(); }
+void ZygiskContext::server_specialize_post() {
+    run_modules_post();
+
+    // Arm the live hot-plug path — WITHOUT creating any thread here. See the
+    // block comment above: a thread during specialize bootloops the device.
+    static std::atomic<bool> armed{false};
+    if (!armed.exchange(true)) {
+        JavaVM *vm = nullptr;
+        if (env->GetJavaVM(&vm) == JNI_OK && vm != nullptr) {
+            g_ss_ctx = this;
+            g_ss_vm = vm;
+            struct sigaction sa {};
+            sa.sa_handler = hotplug_signal_handler;
+            sigemptyset(&sa.sa_mask);
+            sa.sa_flags = SA_RESTART;
+            sigaction(kHotplugSignal, &sa, nullptr);
+            LOGI("hot-plug: armed live loader signal in system_server");
+        }
+    }
+}
 
 // -----------------------------------------------------------------
 

--- a/zygiskd/src/zygiskd.rs
+++ b/zygiskd/src/zygiskd.rs
@@ -645,10 +645,61 @@ fn opted_in_staged_modules() -> Vec<(String, PathBuf)> {
 /// launch instead of never. Cheap to call liberally: a directory scan plus
 /// marker checks, and each module is scheduled for real work at most once
 /// (guarded by the marker file itself).
+/// Realtime signal the loader arms a handler for inside system_server (see
+/// `kHotplugSignal` in loader/src/injector/module.cpp). Must match that value.
+const HOTPLUG_SIGNAL: i32 = 40;
+
+/// The pid of the running `system_server`, found by scanning `/proc`.
+fn pidof_system_server() -> Option<i32> {
+    for entry in fs::read_dir("/proc").ok()?.flatten() {
+        let Ok(pid) = entry.file_name().to_string_lossy().parse::<i32>() else {
+            continue;
+        };
+        if let Ok(cmdline) = fs::read_to_string(format!("/proc/{pid}/cmdline")) {
+            if cmdline.split('\0').next() == Some("system_server") {
+                return Some(pid);
+            }
+        }
+    }
+    None
+}
+
+/// Poke the live system_server (once per boot) to load hot-plugged modules
+/// into itself — the zero-reboot path for framework modules like LSPosed.
+///
+/// Deliberately only fires after `system_server_ready()` (boot complete): the
+/// loader's handler spawns a worker thread, and a thread inside system_server
+/// during its early specialize window bootloops the device (setcon requires a
+/// single-threaded process). By boot-complete that window is long past.
+///
+/// Gated on the user having opted at least one module into hot-plug
+/// (`WORKDIR/hotplug/*`); a no-op otherwise. Signals at most once per daemon
+/// lifetime — the loader-side worker de-duplicates and loads everything served.
+fn signal_system_server_hotplug() {
+    static SIGNALED: AtomicBool = AtomicBool::new(false);
+    let hotplug_dir = Path::new(TMP_PATH.get().unwrap()).join("hotplug");
+    let has_optin = fs::read_dir(&hotplug_dir)
+        .map(|mut d| d.next().is_some())
+        .unwrap_or(false);
+    if !has_optin || SIGNALED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    match pidof_system_server() {
+        Some(pid) => {
+            let r = unsafe { libc::kill(pid, HOTPLUG_SIGNAL) };
+            info!("Hot-plug: signaled system_server (pid {}) to live-load modules (ret {})", pid, r);
+        }
+        None => warn!("Hot-plug: system_server pid not found; cannot live-load"),
+    }
+}
+
 fn run_pending_staged_services() {
     if !system_server_ready() {
         return;
     }
+    // Zero-reboot framework activation: tell the live system_server to pull in
+    // hot-plugged modules. See signal_system_server_hotplug.
+    signal_system_server_hotplug();
     let markers = Path::new(TMP_PATH.get().unwrap()).join("hotplug_activated");
     let Ok(dir) = fs::read_dir(&markers) else {
         return;


### PR DESCRIPTION
An actual attempt at the goal: activate a framework module (LSPosed) inside the **already-running** system_server with **no reboot**.

## The constraint learned the hard way

Four bootloops (v349–v355) established: a thread must not exist inside system_server while it's being specialized — a process with >1 thread cannot complete `setcon()` during `SpecializeCommon`. Every build that spawned the poller thread in `server_specialize_pre` **or** `_post` bootlooped deterministically. v356 (no thread) boots, but then never live-loads, so LSPosed never activates.

## New approach: no thread at specialize, signal-triggered thread post-boot

- `server_specialize_post` creates **no thread** — it only **arms a realtime signal handler** (single-threaded, setcon-safe).
- The daemon sends `kill(system_server, 40)` **only after `sys.boot_completed`** — long past the specialize window, when system_server is fully up and already massively multi-threaded.
- The handler then spawns a short-lived worker that pulls the module list and loads any not-yet-loaded module into the live system_server (`memfd load + onLoad + preServerSpecialize`) — the path that could never run before because the thread crashed boot first.

## Honest status — experiment, unverified

I cannot test this without a device. Two open risks:
1. Spawning the worker from a signal handler isn't strictly async-signal-safe (could deadlock if it interrupts `malloc`; the signal is sent at an idle-ish post-boot moment to minimize it).
2. Even if it runs cleanly, whether live `preServerSpecialize` makes LSPosed actually report **"activated"** is the untested core hypothesis.

Per the device owner's explicit choice, **shipping without a bootloop guard**. Both components build clean (all four ABIs). Please capture a **logcat** after flashing regardless of outcome — if it crashes, that backtrace finally tells us why; if it boots but LSPosed still isn't activated, that settles whether live injection can work at all.
