### PR TITLE
fix(hotplug): activate framework modules via a clean system_server restart, not a crash

### DIFF
--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -9,13 +9,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <csignal>
-
 #include <algorithm>
-#include <atomic>
-#include <mutex>
 #include <string>
-#include <thread>
 #include <vector>
 
 #include <lsplt.hpp>
@@ -455,98 +450,22 @@ void ZygiskContext::app_specialize_post() {
     env->ReleaseStringUTFChars(args.app->nice_name, process);
 }
 
-// ── live hot-plug into the already-running system_server ──
-//
-// Framework modules (LSPosed) only take effect inside system_server, and the
-// goal is zero reboot. The hard constraint learned the painful way: a thread
-// must NOT exist inside system_server while it is being specialized — a
-// process with >1 thread cannot complete selinux_android_setcontext ->
-// setcon() during SpecializeCommon, which bootlooped every build that spawned
-// a thread in server_specialize_pre OR _post (v349–v355).
-//
-// So at specialize time we create no thread — we only ARM a realtime signal
-// handler (cheap, single-threaded, setcon-safe). The daemon sends that signal
-// only AFTER sys.boot_completed, i.e. long past the specialize window, when
-// system_server is fully up and already massively multi-threaded. The handler
-// then spawns a short-lived worker that pulls the current module list from the
-// daemon and loads any not-yet-loaded module into this live system_server.
-//
-// Signal 40 is a realtime signal (bionic reserves 32–34; 40 sits in the
-// user-available range) agreed with the daemon (see zygiskd's
-// signal_system_server_hotplug).
-static constexpr int kHotplugSignal = 40;
-static ZygiskContext *g_ss_ctx = nullptr;
-static JavaVM *g_ss_vm = nullptr;
-
-/// One pass: load every served module this system_server has not loaded yet.
-/// Runs on a worker thread spawned post-boot, never during specialize.
-static void hotplug_load_once() {
-    static std::mutex mtx;
-    static std::vector<std::string> loaded;
-    std::lock_guard<std::mutex> lk(mtx);
-
-    if (g_ss_ctx == nullptr || g_ss_vm == nullptr) return;
-    JNIEnv *penv = nullptr;
-    if (g_ss_vm->GetEnv(reinterpret_cast<void **>(&penv), JNI_VERSION_1_6) != JNI_OK) {
-        if (g_ss_vm->AttachCurrentThread(&penv, nullptr) != JNI_OK) return;
-    }
-
-    auto ms = zygiskd::ReadModules();
-    for (size_t i = 0; i < ms.size(); i++) {
-        auto &m = ms[i];
-        if (std::find(loaded.begin(), loaded.end(), m.name) != loaded.end()) continue;
-        if (LoadedModule lm = LoadModuleFromMemfd(m.memfd)) {
-            LOGI("hot-plug: loading module `%s` into live system_server", m.name.c_str());
-            g_ss_ctx->modules.emplace_back(static_cast<int>(i), lm.handle, lm.entry, lm.custom);
-            auto &mod = g_ss_ctx->modules.back();
-            mod.onLoad(penv);
-            // preServerSpecialize with fresh args — the specialize-time struct
-            // is long gone. LSPosed-class modules only read the env.
-            jint uid = 1000, gid = 1000, runtime_flags = 0;
-            jintArray gids = nullptr;
-            jlong caps = 0;
-            ServerSpecializeArgs_v1 args(uid, gid, gids, runtime_flags, caps, caps);
-            mod.preServerSpecialize(&args);
-            loaded.push_back(m.name);
-        }
-    }
-}
-
-/// Realtime-signal handler armed in system_server. Spawns the worker thread.
-/// Only ever runs post-boot (the daemon gates the signal on boot_completed),
-/// so creating a thread here is safe — the setcon single-thread requirement
-/// applies only during SpecializeCommon, which finished long ago.
-static void hotplug_signal_handler(int) {
-    if (g_ss_ctx != nullptr && g_ss_vm != nullptr) {
-        std::thread(hotplug_load_once).detach();
-    }
-}
+// Live injection into an already-running system_server was tried (a worker
+// thread pulling modules and calling preServerSpecialize) and is a dead end:
+// device logs proved it deterministically SIGSEGVs system_server the instant
+// the load runs. A framework module (LSPosed) only activates when it is loaded
+// at system_server's *fork/specialize* — never mid-life. So a module
+// hot-plugged after boot is activated by re-forking system_server once (a
+// controlled ~15s framework restart, not a full reboot); the daemon does that
+// after swapping the module into the active directory. See
+// zygiskd::activate_staged_module.
 
 void ZygiskContext::server_specialize_pre() {
     run_modules_pre();
     zygiskd::SystemServerStarted();
 }
 
-void ZygiskContext::server_specialize_post() {
-    run_modules_post();
-
-    // Arm the live hot-plug path — WITHOUT creating any thread here. See the
-    // block comment above: a thread during specialize bootloops the device.
-    static std::atomic<bool> armed{false};
-    if (!armed.exchange(true)) {
-        JavaVM *vm = nullptr;
-        if (env->GetJavaVM(&vm) == JNI_OK && vm != nullptr) {
-            g_ss_ctx = this;
-            g_ss_vm = vm;
-            struct sigaction sa {};
-            sa.sa_handler = hotplug_signal_handler;
-            sigemptyset(&sa.sa_mask);
-            sa.sa_flags = SA_RESTART;
-            sigaction(kHotplugSignal, &sa, nullptr);
-            LOGI("hot-plug: armed live loader signal in system_server");
-        }
-    }
-}
+void ZygiskContext::server_specialize_post() { run_modules_post(); }
 
 // -----------------------------------------------------------------
 

--- a/zygiskd/src/zygiskd.rs
+++ b/zygiskd/src/zygiskd.rs
@@ -599,6 +599,7 @@ fn activate_staged_module(name: &str, module_dir: &Path) {
     if !marker_svc.exists() && system_server_ready() {
         let dir_clone = dir.clone();
         let marker_clone = marker_svc.clone();
+        let name_clone = name.to_string();
         std::thread::spawn(move || {
             let p = dir_clone.join("service.sh");
             if p.is_file() {
@@ -608,6 +609,10 @@ fn activate_staged_module(name: &str, module_dir: &Path) {
                 let _ = fs::create_dir_all(parent);
             }
             let _ = fs::write(&marker_clone, b"1");
+            // lspd (and any service.sh daemon) is now up. Re-fork
+            // system_server once so this freshly hot-plugged framework module
+            // loads at specialize and actually activates — no full reboot.
+            restart_system_server_once(&name_clone);
         });
         info!("Hot-plug: scheduling service.sh for swapped module \"{}\"", name);
     }
@@ -645,10 +650,6 @@ fn opted_in_staged_modules() -> Vec<(String, PathBuf)> {
 /// launch instead of never. Cheap to call liberally: a directory scan plus
 /// marker checks, and each module is scheduled for real work at most once
 /// (guarded by the marker file itself).
-/// Realtime signal the loader arms a handler for inside system_server (see
-/// `kHotplugSignal` in loader/src/injector/module.cpp). Must match that value.
-const HOTPLUG_SIGNAL: i32 = 40;
-
 /// The pid of the running `system_server`, found by scanning `/proc`.
 fn pidof_system_server() -> Option<i32> {
     for entry in fs::read_dir("/proc").ok()?.flatten() {
@@ -664,32 +665,36 @@ fn pidof_system_server() -> Option<i32> {
     None
 }
 
-/// Poke the live system_server (once per boot) to load hot-plugged modules
-/// into itself — the zero-reboot path for framework modules like LSPosed.
-///
-/// Deliberately only fires after `system_server_ready()` (boot complete): the
-/// loader's handler spawns a worker thread, and a thread inside system_server
-/// during its early specialize window bootloops the device (setcon requires a
-/// single-threaded process). By boot-complete that window is long past.
-///
-/// Gated on the user having opted at least one module into hot-plug
-/// (`WORKDIR/hotplug/*`); a no-op otherwise. Signals at most once per daemon
-/// lifetime — the loader-side worker de-duplicates and loads everything served.
-fn signal_system_server_hotplug() {
-    static SIGNALED: AtomicBool = AtomicBool::new(false);
-    let hotplug_dir = Path::new(TMP_PATH.get().unwrap()).join("hotplug");
-    let has_optin = fs::read_dir(&hotplug_dir)
-        .map(|mut d| d.next().is_some())
-        .unwrap_or(false);
-    if !has_optin || SIGNALED.swap(true, Ordering::Relaxed) {
+/// Restart just system_server (a ~15s framework "soft reboot", not a device
+/// reboot) so a freshly hot-plugged framework module (LSPosed) is loaded at
+/// the fresh fork/specialize — the ONLY point a framework module activates.
+/// Killing system_server makes init respawn zygote's system_server; our
+/// nativeForkSystemServer hook then injects the now-active module the normal,
+/// crash-free way. Guarded by a one-shot marker so it happens once per
+/// hot-plug, never on an ordinary boot (where the module is already active and
+/// no swap runs).
+fn restart_system_server_once(name: &str) {
+    let marker = Path::new(TMP_PATH.get().unwrap())
+        .join("hotplug_activated")
+        .join(format!("{name}.restarted"));
+    if marker.exists() {
         return;
     }
+    if let Some(parent) = marker.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = fs::write(&marker, b"1");
     match pidof_system_server() {
         Some(pid) => {
-            let r = unsafe { libc::kill(pid, HOTPLUG_SIGNAL) };
-            info!("Hot-plug: signaled system_server (pid {}) to live-load modules (ret {})", pid, r);
+            info!(
+                "Hot-plug: restarting system_server (pid {}) to activate framework module \"{}\"",
+                pid, name
+            );
+            unsafe {
+                libc::kill(pid, libc::SIGKILL);
+            }
         }
-        None => warn!("Hot-plug: system_server pid not found; cannot live-load"),
+        None => warn!("Hot-plug: system_server pid not found; cannot restart to activate \"{}\"", name),
     }
 }
 
@@ -697,9 +702,6 @@ fn run_pending_staged_services() {
     if !system_server_ready() {
         return;
     }
-    // Zero-reboot framework activation: tell the live system_server to pull in
-    // hot-plugged modules. See signal_system_server_hotplug.
-    signal_system_server_hotplug();
     let markers = Path::new(TMP_PATH.get().unwrap()).join("hotplug_activated");
     let Ok(dir) = fs::read_dir(&markers) else {
         return;
@@ -721,12 +723,17 @@ fn run_pending_staged_services() {
         }
         let dir_clone = active_dir.clone();
         let marker_clone = markers.join(format!("{name}.service"));
+        let name_clone = name.to_string();
         std::thread::spawn(move || {
             let p = dir_clone.join("service.sh");
             if p.is_file() {
                 run_module_script(&dir_clone, &p);
             }
             let _ = fs::write(&marker_clone, b"1");
+            // Re-fork system_server once so this freshly hot-plugged framework
+            // module activates at specialize — no full reboot. See
+            // restart_system_server_once.
+            restart_system_server_once(&name_clone);
         });
         info!("Hot-plug: scheduling deferred service.sh for swapped module \"{}\"", name);
     }


### PR DESCRIPTION
Device logs settled it definitively. The previous build's signal-triggered live injection made system_server **SIGSEGV 1ms after** the daemon signaled it:

```
15:27:35.391 zygiskd64: Hot-plug: signaled system_server (pid 1958) ... (ret 0)
15:27:35.392 libc: Fatal signal 11 (SIGSEGV) ... in system_server, pid 1958
```

LSPosed still ended up "activated" — but only because that **crash** restarted system_server, and the restarted one loaded the module normally at its fresh fork. So: live injection into a running system_server is a **confirmed dead end** (it crashes), and worse, the daemon sent that signal on **every boot**, so the device soft-rebooted every single boot.

## The honest mechanism

A framework module (LSPosed) only activates when loaded at system_server's fork/specialize — never mid-life. So: swap the module into the active dir (already done), then re-fork system_server **once, cleanly**.

`restart_system_server_once()` fires after a freshly hot-plugged module's `service.sh` has run (lspd up): it kills system_server so init respawns it, and our `nativeForkSystemServer` hook injects the now-active module the normal, crash-free way. Guarded by a per-module `.restarted` marker → fires exactly once per hot-plug, **never on an ordinary boot** (where the module is already active, no swap runs, and LSPosed activates at fork with no restart at all).

The entire live-injection path (signal handler + worker thread) is removed from the loader — it only ever crashed.

## Net behaviour

- Ordinary boots: **no soft reboot** (the every-boot crash is gone); LSPosed active at fork.
- A fresh framework-module hot-plug: **one controlled ~15s framework restart** (not a full device reboot), then active.
- App-hooking modules: unaffected, still need no restart.

Both components build clean (all four ABIs).
