### PR TITLE
feat: selectable mount mode (revert-only / namespace-switch / global)

### DIFF
--- a/loader/src/injector/hook.cpp
+++ b/loader/src/injector/hook.cpp
@@ -102,17 +102,33 @@ DCL_HOOK_FUNC(static char *, strdup, const char *str) {
 // Skip actual fork and return cached result if applicable
 DCL_HOOK_FUNC(int, fork) { return (g_ctx && g_ctx->pid >= 0) ? g_ctx->pid : old_fork(); }
 
-// Unmount stuffs in the process's private mount namespace
+// Set up the app's private mount namespace according to the selected mount
+// mode (see module.hpp / zygiskd's ProcessFlags):
+//   • global        — every app keeps module mounts; do nothing here.
+//   • namespace swap — denylisted apps setns into the cached clean namespace;
+//                      trusted apps inherit the (never-unmounted) zygote.
+//   • revert only    — modules were unmounted from zygote already, so trusted
+//                      apps setns back into Root to regain them; denylisted
+//                      apps simply inherit the clean zygote (no setns).
 DCL_HOOK_FUNC(static int, unshare, int flags) {
-    if (g_ctx && (flags & CLONE_NEWNS) && !(g_ctx->flags & SERVER_FORK_AND_SPECIALIZE)) {
+    if (g_ctx && (flags & CLONE_NEWNS) && !(g_ctx->flags & SERVER_FORK_AND_SPECIALIZE) &&
+        !(g_ctx->info_flags & MOUNT_MODE_GLOBAL)) {
         bool should_unmount = !(g_ctx->info_flags & (PROCESS_IS_MANAGER | PROCESS_GRANTED_ROOT)) &&
                               g_ctx->flags & DO_REVERT_UNMOUNT;
-        if (!should_unmount && g_hook->zygote_unmounted) {
-            ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Root);
-        }
-        bool is_zygote_clean = g_hook->zygote_unmounted && g_hook->zygote_traces.size() == 0;
-        if (should_unmount && !is_zygote_clean) {
-            ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Clean);
+
+        if (g_ctx->info_flags & MOUNT_MODE_SETNS) {
+            // Zygote was never unmounted in this mode: only denylisted apps
+            // need switching, into the cached clean namespace.
+            if (should_unmount) {
+                ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Clean);
+            }
+        } else {
+            // Revert-only: zygote had its module mounts stripped.
+            if (!should_unmount && g_hook->zygote_unmounted) {
+                ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Root);
+            }
+            // Denylisted apps rely on inheriting the clean zygote; no setns
+            // fallback (that is what makes this "revert only").
         }
     }
 

--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -539,27 +539,33 @@ void ZygiskContext::nativeForkAndSpecialize_pre() {
     LOGV("pre forkAndSpecialize [%s]", process);
     flags |= APP_FORK_AND_SPECIALIZE;
 
+    // Direct zygote unmounting is the "revert only" mount mode only. In the
+    // "namespace switch" and "global" modes the zygote keeps its module mounts
+    // (denylisted apps are handled by setns / not at all — see the unshare
+    // hook), so this whole step is skipped.
     if (!g_hook->zygote_unmounted && g_hook->zygote_traces.size() == 0) {
         info_flags = zygiskd::GetProcessFlags(args.app->uid);
 
-        g_hook->zygote_traces = check_zygote_traces(info_flags);
+        if (!(info_flags & (MOUNT_MODE_SETNS | MOUNT_MODE_GLOBAL))) {
+            g_hook->zygote_traces = check_zygote_traces(info_flags);
 
-        if (!abort_zygote_unmount(g_hook->zygote_traces, info_flags)) {
-            auto removal_predicate = [](const mount_info &trace) {
-                LOGV("unmounting %s (mnt_id: %u)", trace.target.c_str(), trace.id);
-                if (umount2(trace.target.c_str(), MNT_DETACH) == 0) {
-                    return true;  // Success: Mark for removal.
-                } else {
-                    LOGE("failed to unmount %s: %s", trace.target.c_str(), strerror(errno));
-                    return false;  // Failure: Keep this trace in the vector.
-                }
-            };
+            if (!abort_zygote_unmount(g_hook->zygote_traces, info_flags)) {
+                auto removal_predicate = [](const mount_info &trace) {
+                    LOGV("unmounting %s (mnt_id: %u)", trace.target.c_str(), trace.id);
+                    if (umount2(trace.target.c_str(), MNT_DETACH) == 0) {
+                        return true;  // Success: Mark for removal.
+                    } else {
+                        LOGE("failed to unmount %s: %s", trace.target.c_str(), strerror(errno));
+                        return false;  // Failure: Keep this trace in the vector.
+                    }
+                };
 
-            auto new_end = std::remove_if(g_hook->zygote_traces.begin(),
-                                          g_hook->zygote_traces.end(), removal_predicate);
+                auto new_end = std::remove_if(g_hook->zygote_traces.begin(),
+                                              g_hook->zygote_traces.end(), removal_predicate);
 
-            g_hook->zygote_traces.erase(new_end, g_hook->zygote_traces.end());
-            g_hook->zygote_unmounted = true;
+                g_hook->zygote_traces.erase(new_end, g_hook->zygote_traces.end());
+                g_hook->zygote_unmounted = true;
+            }
         }
     }
 

--- a/loader/src/injector/module.hpp
+++ b/loader/src/injector/module.hpp
@@ -148,13 +148,18 @@ enum : uint32_t {
     PROCESS_GRANTED_ROOT = zygisk::StateFlag::PROCESS_GRANTED_ROOT,
     PROCESS_ON_DENYLIST = zygisk::StateFlag::PROCESS_ON_DENYLIST,
 
+    // Mount mode, chosen by the user (WebUI). Kept in sync with the daemon's
+    // ProcessFlags (zygiskd/src/constants.rs). Neither bit = "revert only".
+    MOUNT_MODE_SETNS = (1u << 2),
+    MOUNT_MODE_GLOBAL = (1u << 3),
+
     PROCESS_IS_MANAGER = (1u << 27),
     PROCESS_ROOT_IS_APATCH = (1u << 28),
     PROCESS_ROOT_IS_KSU = (1u << 29),
     PROCESS_ROOT_IS_MAGISK = (1u << 30),
 
-    PRIVATE_MASK = (PROCESS_IS_MANAGER | PROCESS_ROOT_IS_APATCH | PROCESS_ROOT_IS_KSU |
-                    PROCESS_ROOT_IS_MAGISK),
+    PRIVATE_MASK = (MOUNT_MODE_SETNS | MOUNT_MODE_GLOBAL | PROCESS_IS_MANAGER |
+                    PROCESS_ROOT_IS_APATCH | PROCESS_ROOT_IS_KSU | PROCESS_ROOT_IS_MAGISK),
     UNMOUNT_MASK = PROCESS_ON_DENYLIST
 };
 

--- a/zygiskd/src/constants.rs
+++ b/zygiskd/src/constants.rs
@@ -91,6 +91,13 @@ bitflags! {
         const PROCESS_GRANTED_ROOT = 1 << 0;
         /// The process is on the denylist and module mounts should be hidden.
         const PROCESS_ON_DENYLIST = 1 << 1;
+        /// Mount mode "namespace switch": hide by setns-ing denylisted apps into
+        /// the cached clean namespace instead of unmounting from zygote. Neither
+        /// this nor MOUNT_MODE_GLOBAL set = "revert only" (unmount from zygote).
+        const MOUNT_MODE_SETNS = 1 << 2;
+        /// Mount mode "global": mount modules into every app, never unmount for
+        /// the denylist. Only su/root visibility is hidden.
+        const MOUNT_MODE_GLOBAL = 1 << 3;
         /// The process is the root manager application itself.
         const PROCESS_IS_MANAGER = 1 << 27;
         /// The active root solution is APatch.

--- a/zygiskd/src/zygiskd.rs
+++ b/zygiskd/src/zygiskd.rs
@@ -859,9 +859,24 @@ fn handle_get_process_flags(stream: &mut UnixStream) -> Result<()> {
         _ => (), // No flag for None, TooOld, or Multiple
     }
 
+    flags |= mount_mode_flag();
+
     trace!("Flags for UID {}: {:?}", uid, flags);
     stream.write_u32(flags.bits())?;
     Ok(())
+}
+
+/// The user-selected mount mode, read fresh from `WORKDIR/mount_mode` (so a
+/// change takes effect on the next app launch, no restart). Values: `setns`,
+/// `global`, or anything else / missing = the default "revert only". Rides
+/// along in the process flags so the loader can apply it per fork.
+fn mount_mode_flag() -> ProcessFlags {
+    let path = Path::new(TMP_PATH.get().unwrap()).join("mount_mode");
+    match fs::read_to_string(path).ok().as_deref().map(str::trim) {
+        Some("setns") => ProcessFlags::MOUNT_MODE_SETNS,
+        Some("global") => ProcessFlags::MOUNT_MODE_GLOBAL,
+        _ => ProcessFlags::empty(), // "revert" (default)
+    }
 }
 
 fn handle_update_mount_namespace(stream: &mut UnixStream, context: &AppContext) -> Result<()> {

--- a/zygiskd/webui/src/api/system.ts
+++ b/zygiskd/webui/src/api/system.ts
@@ -31,6 +31,8 @@ const STATUS_SCRIPT = [
   // Hot-plug master switch: off (WORKDIR/hotplug_off present) means staged
   // updates only apply at the root solution's own boot-time swap.
   'echo "hotplug=$([ -f "$W/hotplug_off" ] && echo 0 || echo 1)"',
+  // Mount mode: revert (default) | setns | global. See setMountMode.
+  'echo "mount_mode=$(cat "$W/mount_mode" 2>/dev/null || echo revert)"',
   'echo "@@monitor"',
   'cat "$W/module.prop" 2>/dev/null | head -c 600; echo',
   'echo "@@modules"',
@@ -199,6 +201,19 @@ export async function setModuleHotplug(id: string, enabled: boolean): Promise<vo
 export async function setHotplugMaster(enabled: boolean): Promise<void> {
   const flag = `${WORKDIR}/hotplug_off`;
   await exec(enabled ? `rm -f '${flag}'` : `touch '${flag}'`);
+}
+
+/** Mount mode for denylisted apps, applied by the daemon/loader on the next
+ * app launch (no restart). One of:
+ *  - "revert": unmount module/root traces directly from zygote (default);
+ *  - "setns":  switch denylisted apps into a cached clean namespace;
+ *  - "global": mount modules into every app, hide only su/root.
+ * Stored in WORKDIR/mount_mode; see zygiskd::mount_mode_flag. */
+export type MountMode = "revert" | "setns" | "global";
+export async function setMountMode(mode: MountMode): Promise<void> {
+  const flag = `${WORKDIR}/mount_mode`;
+  // "revert" is the default — clear the file rather than storing it.
+  await exec(mode === "revert" ? `rm -f '${flag}'` : `printf '%s' '${mode}' > '${flag}'`);
 }
 
 /** Normalize version display: strip a leading v/V then add one. */

--- a/zygiskd/webui/src/components/SettingsSection.vue
+++ b/zygiskd/webui/src/components/SettingsSection.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 /* Settings section — theme, language, hot-plug master switch. */
 import { inject, ref } from "vue";
-import { setHotplugMaster } from "../api/system";
+import { setHotplugMaster, setMountMode } from "../api/system";
+import type { MountMode } from "../api/system";
 import { useLocale } from "../composables/useLocale";
 import { AUTO_LOCALE } from "../composables/useLocale";
 import type { LocalePref } from "../composables/useLocale";
@@ -18,7 +19,9 @@ const theme = ref<ThemePref>(getThemePref());
 
 // Shared 6s-polled state (provided by App.vue); local fallback for standalone.
 const state = inject<MonitorState | null>(MONITOR_STATE_KEY, null) ?? useMonitorState();
-const { hotplug, load } = state;
+const { hotplug, mountMode, load } = state;
+
+const MOUNT_MODES: MountMode[] = ["revert", "setns", "global"];
 
 function cap(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
@@ -41,6 +44,15 @@ async function toggleHotplug(enabled: boolean): Promise<void> {
     await load();
   } catch (e) {
     /* the next poll re-syncs the switch state */
+  }
+}
+
+async function onMountMode(e: Event): Promise<void> {
+  try {
+    await setMountMode((e.target as HTMLSelectElement).value as MountMode);
+    await load();
+  } catch (e) {
+    /* the next poll re-syncs the dropdown */
   }
 }
 </script>
@@ -71,6 +83,17 @@ async function toggleHotplug(enabled: boolean): Promise<void> {
           <span class="hint">{{ t("settings.hotplugHint") }}</span>
         </span>
         <Switch :checked="hotplug" @update:checked="toggleHotplug" />
+      </div>
+      <div class="setting-row">
+        <span class="s-label">
+          {{ t("settings.mountMode") }}
+          <span class="hint">{{ t(`settings.mountMode_${mountMode}_hint`) }}</span>
+        </span>
+        <select :value="mountMode" @change="onMountMode">
+          <option v-for="m in MOUNT_MODES" :key="m" :value="m">
+            {{ t(`settings.mountMode_${m}`) }}
+          </option>
+        </select>
       </div>
     </Card>
 

--- a/zygiskd/webui/src/composables/useMonitorState.ts
+++ b/zygiskd/webui/src/composables/useMonitorState.ts
@@ -23,6 +23,7 @@ export interface MonitorState {
   rootImpl: Ref<string>;
   version: Ref<string>;
   hotplug: Ref<boolean>;
+  mountMode: Ref<string>;
   load: () => Promise<void>;
 }
 
@@ -35,6 +36,7 @@ export function useMonitorState(): MonitorState {
   const rootImpl = ref("");
   const version = ref("");
   const hotplug = ref(true);
+  const mountMode = ref("revert");
   const { locale } = useLocale();
 
   let timer: number | undefined;
@@ -45,6 +47,7 @@ export function useMonitorState(): MonitorState {
       rootImpl.value = d.keys.root || "";
       version.value = d.keys.version || "";
       hotplug.value = d.keys.hotplug !== "0";
+      mountMode.value = d.keys.mount_mode || "revert";
       monitor.value = parseMonitor(d.monitor);
       modules.value = d.modules;
       fns.value = d.fns;
@@ -64,5 +67,5 @@ export function useMonitorState(): MonitorState {
   // Reload on language switch (dev mock data follows the locale).
   watch(locale, () => load());
 
-  return { loading, error, monitor, modules, fns, rootImpl, version, hotplug, load };
+  return { loading, error, monitor, modules, fns, rootImpl, version, hotplug, mountMode, load };
 }

--- a/zygiskd/webui/src/locales/en_US.json
+++ b/zygiskd/webui/src/locales/en_US.json
@@ -69,6 +69,13 @@
     "about": "About",
     "aboutText": "OnyxZygisk — a Zygisk implementation via ptrace, with FN (Functional Node) modules. Fork of NeoZygisk.",
     "hotplug": "Hot-plug (Zygisk Host)",
-    "hotplugHint": "When off, modules take effect only after a reboot"
+    "hotplugHint": "When off, modules take effect only after a reboot",
+    "mountMode": "Mount mode",
+    "mountMode_revert": "Revert only",
+    "mountMode_revert_hint": "Unmount module/root traces directly from zygote",
+    "mountMode_setns": "Namespace switch",
+    "mountMode_setns_hint": "Switch denylisted apps into a clean namespace",
+    "mountMode_global": "Global",
+    "mountMode_global_hint": "Mount modules into every app; hide only su/root"
   }
 }

--- a/zygiskd/webui/src/locales/ja_JP.json
+++ b/zygiskd/webui/src/locales/ja_JP.json
@@ -69,6 +69,13 @@
     "about": "このモジュールについて",
     "aboutText": "OnyxZygisk — ptrace ベースの Zygisk 実装で、FN（Functional Node）モジュールに対応しています。NeoZygisk のフォークです。",
     "hotplug": "ホットプラグ（Zygisk Host）",
-    "hotplugHint": "オフの間は再起動後にのみ有効"
+    "hotplugHint": "オフの間は再起動後にのみ有効",
+    "mountMode": "マウントモード",
+    "mountMode_revert": "復元のみ",
+    "mountMode_revert_hint": "zygote から直接モジュール/root の痕跡をアンマウント",
+    "mountMode_setns": "名前空間切替",
+    "mountMode_setns_hint": "拒否リストのアプリをクリーンな名前空間へ切替",
+    "mountMode_global": "グローバル",
+    "mountMode_global_hint": "全アプリにモジュールをマウントし su/root のみ隠す"
   }
 }

--- a/zygiskd/webui/src/locales/zh_CN.json
+++ b/zygiskd/webui/src/locales/zh_CN.json
@@ -69,6 +69,13 @@
     "about": "关于",
     "aboutText": "OnyxZygisk —— 基于 ptrace 的 Zygisk 实现，支持 FN（Functional Node）模块。fork 自 NeoZygisk。",
     "hotplug": "热插拔（Zygisk Host）",
-    "hotplugHint": "关闭后模块需重启才生效"
+    "hotplugHint": "关闭后模块需重启才生效",
+    "mountMode": "挂载模式",
+    "mountMode_revert": "仅还原挂载",
+    "mountMode_revert_hint": "直接从 zygote 卸载模块/root 痕迹",
+    "mountMode_setns": "命名空间切换",
+    "mountMode_setns_hint": "把 denylist 应用切进纯净命名空间",
+    "mountMode_global": "全局挂载",
+    "mountMode_global_hint": "所有应用都挂模块，仅隐藏 su/root"
   }
 }


### PR DESCRIPTION
Adds a global **mount-mode** selector to the WebUI settings, controlling how denylisted apps get their environment. Three modes, each genuinely distinct:

| Mode | Behaviour | Characteristic |
|---|---|---|
| **Revert only** (default) | Unmount module/root traces directly from zygote; denylisted apps inherit the clean zygote, trusted apps setns back into Root | Lightweight, direct; **no** clean-namespace setns fallback (that's what makes it "revert only") |
| **Namespace switch** | Never unmount from zygote; denylisted apps setns into the cached clean namespace, trusted apps inherit zygote's modules | Guaranteed-clean namespace; better on OEMs where direct unmount is fragile |
| **Global** | Mount modules into every app, never unmount for the denylist; only su/root hidden | Max module compatibility, weakest hiding |

## Plumbing

Two `ProcessFlags` bits (`MOUNT_MODE_SETNS` / `MOUNT_MODE_GLOBAL`, neither = revert) carry the mode to the loader per fork, alongside the existing flags. The daemon reads `WORKDIR/mount_mode` **fresh on each `GetProcessFlags`**, so a change takes effect on the next app launch with no restart. The loader branches on the bits in `nativeForkAndSpecialize_pre` (whether to unmount zygote at all) and in the `unshare` hook (which namespace, if any, to setns into). The bits are in `PRIVATE_MASK`, so modules never see them via `getFlags`.

## WebUI

Mount-mode dropdown in Settings with a per-mode hint, `setMountMode` writer (`WORKDIR/mount_mode`; selecting "revert" clears the file), `mount_mode` surfaced in the status script + shared state. Locale strings for en/zh/ja.

## Verification

`vue-tsc` clean, 46/46 WebUI tests pass, dropdown verified rendering in the dev preview, full module build clean across all four ABIs. Runtime mount behaviour itself is best confirmed on-device.
