### PR TITLE
fix: persist hot-plug (and mount-mode) state across reboots

### DIFF
--- a/module/src/post-fs-data.sh
+++ b/module/src/post-fs-data.sh
@@ -28,11 +28,16 @@ create_sys_perm() {
 
 TMP_PATH=@WORK_DIRECTORY@
 
-if [ -d $TMP_PATH ]; then
-  rm -rf $TMP_PATH
-fi
-
+# This work dir holds BOTH fresh-every-boot runtime state (IPC sockets, the
+# copied libzygisk.so) and PERSISTENT user settings that must survive a reboot:
+# the hot-plug opt-in flags (hotplug/<id>), the hot-plug master switch
+# (hotplug_off), the mount mode (mount_mode) and the activation markers
+# (hotplug_activated/). The old code did `rm -rf $TMP_PATH` here, which wiped
+# all of that on every boot — so after a reboot a hot-plugged module lost its
+# hot-plug state entirely and the mount-mode selection reset to default. Keep
+# the directory; only the stale runtime IPC from the previous boot is cleared.
 create_sys_perm $TMP_PATH
+rm -f "$TMP_PATH"/*.sock "$TMP_PATH/init_monitor"
 
 if [ -f $MODDIR/lib64/libzygisk.so ];then
   create_sys_perm $TMP_PATH/lib64

--- a/zygiskd/webui/src/components/ModulesSection.vue
+++ b/zygiskd/webui/src/components/ModulesSection.vue
@@ -53,8 +53,12 @@ async function toggleHotplug(m: ModuleInfo, enabled: boolean) {
           <div class="mod-row__foot">
             <span class="mod-row__author">{{ m.author || t("modules.unknownAuthor") }}</span>
             <!-- A staged update can be applied early (plug); a module already
-                 hot-plugged into the active dir keeps a plug/unplug switch. -->
-            <div v-if="m.pendingUpdate || m.hotplugged" class="mod-row__hotplug">
+                 hot-plugged into the active dir, or still opted in after a
+                 reboot, keeps a plug/unplug switch. -->
+            <div
+              v-if="m.pendingUpdate || m.hotplugged || m.hotplugEnabled"
+              class="mod-row__hotplug"
+            >
               <span class="mod-row__hotplug-label">
                 {{ m.pendingUpdate ? t("modules.hotplug") : t("modules.hotplugToggle") }}
                 <span v-if="!hotplug" class="mod-row__hotplug-off">{{ t("modules.hotplugOff") }}</span>


### PR DESCRIPTION
**Reported:** after a reboot, a hot-plugged module's hot-plug switch/state is gone.

## Root cause — in `post-fs-data.sh`, not the WebUI

It ran `rm -rf $TMP_PATH` (`/data/adb/onyxzygisk`) on **every boot**. That work dir holds not just fresh runtime state (IPC sockets, the copied `libzygisk.so`) but also **all the persistent user settings**:

- `hotplug/<id>` — per-module hot-plug opt-in
- `hotplug_off` — hot-plug master switch
- `mount_mode` — the mount mode just added in #37
- `hotplug_activated/` — activation markers

Wiping the whole dir every boot silently reset all of it. So a previously hot-plugged module came back as an ordinary module with no hot-plug control, and the mount mode reset to default.

## Fix

Keep the directory; clear only the stale runtime IPC from the previous boot (`*.sock`, `init_monitor`). The existing `libzygisk.so` copy below overwrites the stale lib. Everything under `/data/adb` is on the persistent `/data` partition, so the settings now survive a reboot as intended.

Also: the WebUI now shows the plug/unplug switch whenever a module is opted in (`hotplugEnabled`), not only when a staged update is pending or the activation marker exists — so the control is always available for a hot-plug-managed module after a reboot.

## Verification

`vue-tsc` clean, 46/46 WebUI tests pass, module builds clean. Verified the built `post-fs-data.sh` expands `@WORK_DIRECTORY@` correctly and no longer `rm -rf`s the work dir. Reboot-persistence itself is best confirmed on-device.
