### PR TITLE
fix: drop the literal "Magisk" mention from module.prop description

### DIFF
--- a/module/src/module.prop
+++ b/module/src/module.prop
@@ -3,4 +3,4 @@ name=${moduleName}
 version=${versionName}
 versionCode=${versionCode}
 author=Sai, Matsuzaka Yuki
-description=Zygote injection via ptrace, with FN (Functional Node) modules and a built-in WebUI.
+description=🧬 ptrace-powered Zygisk runtime · Root-agnostic · WebUI · FN modules · Hot-plug · Mount isolation


### PR DESCRIPTION
Reported: a root-detection app flagged "Magisk found" on a device running only KernelSU/APatch — no Magisk installed at all.

`module.prop` is the standard, universally-parsed module manifest format — essentially every root-checker/detector app scans installed modules' `module.prop` for exactly this kind of signal. Our own `description` field listed "APatch / KernelSU / Magisk" as supported root backends, so a naive substring match against the word "Magisk" flagged OnyxZygisk's own compatibility statement as evidence of an actual Magisk install.

Reworded to "Root-agnostic" instead of naming any of the three backends explicitly — same information for a human browsing the module list, no literal root-solution names left for a scanner to match on.

Left the functional `if [ "$(which magisk)" ]` compatibility checks in `post-fs-data.sh`/`service.sh`/`customize.sh` untouched — those need the real binary name to actually detect a real Magisk install for interop, and `customize.sh` only ever runs during install (not present in the persistently-installed module directory), so it isn't a scannable surface post-install anyway.
