### PR TITLE
chore: clean up shell scripts — quoting, formatting, headers

### DIFF
--- a/module/src/action.sh
+++ b/module/src/action.sh
@@ -1,29 +1,48 @@
 #!/system/bin/sh
-# OnyxZygisk module action: print a clean, human-readable status.
-# The ptrace monitor appends its live status to module.prop with every line
-# tab-prefixed, so a plain `cat` would dump a wall of mangled text. Instead we
-# split it into module metadata ("key=value") and the monitor status rows.
+# ==============================================================================
+# OnyxZygisk · Module action
+#
+# Presents the installed metadata and live monitor state as a compact status
+# card. The monitor file intentionally contains both `key=value` metadata and
+# tab-indented runtime rows, so it is formatted here instead of printed raw.
+# ==============================================================================
 
-printf "Status of OnyxZygisk\n\n"
+MODDIR=${0%/*}
+LIVE_PROP=@WORK_DIRECTORY@/module.prop
+MODULE_PROP="$MODDIR/module.prop"
 
-PROP=@WORK_DIRECTORY@/module.prop
+read_prop() {
+  sed -n "s/^$1=//p" "$MODULE_PROP" 2>/dev/null | head -n 1
+}
 
-if [ ! -f "$PROP" ]; then
-  echo "  (module.prop not found)"
+print_row() {
+  printf '│  %-10s %s\n' "$1" "$2"
+}
+
+printf '\n╭─ 🧬 OnyxZygisk · Runtime Overview\n'
+printf '├─ Module\n'
+print_row "Name" "$(read_prop name)"
+print_row "Version" "$(read_prop version)"
+print_row "Module ID" "$(read_prop id)"
+print_row "Authors" "$(read_prop author)"
+printf '├─ Runtime\n'
+
+if [ ! -f "$LIVE_PROP" ]; then
+  print_row "Runtime" "status is not available yet"
 else
-  echo "Module:"
-  grep -E '^[[:blank:]]*[a-zA-Z][a-zA-Z0-9_]*=' "$PROP" | sed -E 's/^[[:blank:]]+//'
-  echo
-  echo "Monitor:"
-  grep -Ev '^[[:blank:]]*[a-zA-Z][a-zA-Z0-9_]*=|^[[:blank:]]*=' "$PROP" | grep -v '^[[:blank:]]*$' | sed -E 's/^[[:blank:]]+//; s/:[[:blank:]]+/: /' | awk '{ print length($0), $0 }' | sort -n | cut -d' ' -f2-
+  grep -Ev '^[[:blank:]]*[a-zA-Z][a-zA-Z0-9_]*=|^[[:blank:]]*=' "$LIVE_PROP" |
+    sed -E 's/^[[:blank:]]+//; s/:[[:blank:]]+/: /' |
+    while IFS= read -r row; do
+      [ -n "$row" ] && printf '│  %s\n' "$row"
+    done
 fi
 
-echo
-echo "WebUI (webroot): /data/adb/modules/onyxzygisk/webroot/"
-echo "  Open the WebUI from the module page in KernelSU / APatch Manager or MMRL"
-echo "  (The page is read directly by the Manager's WebView; no network or port is needed)"
+printf '├─ WebUI\n'
+print_row "WebUI" "Open from your root manager or MMRL"
+print_row "Path" "/data/adb/modules/onyxzygisk/webroot"
+printf '╰─ No network port required\n\n'
 
 if [ -z "$MMRL" ] && { [ -n "$KSU" ] || [ -n "$APATCH" ]; }; then
-	# Avoid instant exit on KernelSU or APatch
-	sleep 5
+  # Keep the action window visible when the manager closes it immediately.
+  sleep 5
 fi

--- a/module/src/late-load.sh
+++ b/module/src/late-load.sh
@@ -1,8 +1,11 @@
 #!/system/bin/sh
-# KernelSU LKM late-load mode: this runs INSTEAD of post-fs-data.sh, because
-# by the time a late-loaded KernelSU exists, the real post-fs-data boot stage
-# has already passed without it. service.sh and boot-completed.sh still fire
-# normally afterwards through KSU's regular stage sequence.
+# ==============================================================================
+# OnyxZygisk · KernelSU LKM late-load entry
+#
+# A late-loaded KernelSU appears after post-fs-data has already passed, so this
+# entry invokes the shared bootstrap directly. Later lifecycle stages continue
+# through KernelSU's normal service sequence.
+# ==============================================================================
 
 MODDIR=${0%/*}
 cd "$MODDIR"

--- a/module/src/post-fs-data.sh
+++ b/module/src/post-fs-data.sh
@@ -1,4 +1,10 @@
 #!/system/bin/sh
+# ==============================================================================
+# OnyxZygisk · post-fs-data stage
+#
+# Starts the runtime and mirrors the lifecycle scripts of classic Zygisk
+# modules when Magisk's built-in Zygisk is not driving them.
+# ==============================================================================
 
 MODDIR=${0%/*}
 if [ "$ZYGISK_ENABLED" ]; then
@@ -20,4 +26,5 @@ if [ "$(which magisk)" ]; then
   done
 fi
 
+# Enter the shared bootstrap used by both normal and late-load startup.
 . "$MODDIR/zygisk-init.sh"

--- a/module/src/service.sh
+++ b/module/src/service.sh
@@ -1,4 +1,10 @@
 #!/system/bin/sh
+# ==============================================================================
+# OnyxZygisk · late-start service stage
+#
+# Mirrors service.sh for classic Zygisk modules when their lifecycle is not
+# already managed by Magisk's built-in Zygisk implementation.
+# ==============================================================================
 
 DEBUG=@DEBUG@
 

--- a/module/src/uninstall.sh
+++ b/module/src/uninstall.sh
@@ -1,5 +1,10 @@
 #!/system/bin/sh
+# ==============================================================================
+# OnyxZygisk · Uninstall cleanup
+#
+# Removes runtime state and persistent preferences after the module is deleted.
+# ==============================================================================
 
 export TMP_PATH=@WORK_DIRECTORY@
 
-rm -rf $TMP_PATH
+rm -rf "$TMP_PATH"

--- a/module/src/zygisk-init.sh
+++ b/module/src/zygisk-init.sh
@@ -1,41 +1,44 @@
 #!/system/bin/sh
-# Shared by post-fs-data.sh (normal boot) and late-load.sh (KernelSU LKM
-# late-load mode, where post-fs-data.sh never runs — see that file). Caller
-# must set MODDIR to the module directory before sourcing this.
+# ==============================================================================
+# OnyxZygisk · Shared runtime bootstrap
+#
+# Sourced by both normal post-fs-data startup and KernelSU LKM late-load.
+# The caller must define MODDIR before entering this file.
+# ==============================================================================
 
 create_sys_perm() {
-  mkdir -p $1
-  chmod 555 $1
-  chcon u:object_r:system_file:s0 $1
+  mkdir -p "$1"
+  chmod 555 "$1"
+  chcon u:object_r:system_file:s0 "$1"
 }
 
 TMP_PATH=@WORK_DIRECTORY@
 
-# This work dir holds BOTH fresh-every-boot runtime state (IPC sockets, the
-# copied libzygisk.so) and PERSISTENT user settings that must survive a reboot:
-# the hot-plug opt-in flags (hotplug/<id>), the hot-plug master switch
-# (hotplug_off), the mount mode (mount_mode) and the activation markers
-# (hotplug_activated/). Keep the directory; only the stale runtime IPC from
-# the previous boot is cleared.
-create_sys_perm $TMP_PATH
+# ── Workspace ─────────────────────────────────────────────────────────────────
+# Runtime sockets share this directory with persistent user preferences such
+# as hot-plug flags and mount mode. Preserve the directory across reboots and
+# remove only stale IPC endpoints from the previous session.
+create_sys_perm "$TMP_PATH"
 rm -f "$TMP_PATH"/*.sock "$TMP_PATH/init_monitor"
 
-if [ -f $MODDIR/lib64/libzygisk.so ];then
-  create_sys_perm $TMP_PATH/lib64
-  cp $MODDIR/lib64/libzygisk.so $TMP_PATH/lib64/libzygisk.so
-  chcon u:object_r:system_file:s0 $TMP_PATH/lib64/libzygisk.so
+# ── Runtime libraries ─────────────────────────────────────────────────────────
+if [ -f "$MODDIR/lib64/libzygisk.so" ]; then
+  create_sys_perm "$TMP_PATH/lib64"
+  cp "$MODDIR/lib64/libzygisk.so" "$TMP_PATH/lib64/libzygisk.so"
+  chcon u:object_r:system_file:s0 "$TMP_PATH/lib64/libzygisk.so"
 fi
 
-if [ -f $MODDIR/lib/libzygisk.so ];then
-  create_sys_perm $TMP_PATH/lib
-  cp $MODDIR/lib/libzygisk.so $TMP_PATH/lib/libzygisk.so
-  chcon u:object_r:system_file:s0 $TMP_PATH/lib/libzygisk.so
+if [ -f "$MODDIR/lib/libzygisk.so" ]; then
+  create_sys_perm "$TMP_PATH/lib"
+  cp "$MODDIR/lib/libzygisk.so" "$TMP_PATH/lib/libzygisk.so"
+  chcon u:object_r:system_file:s0 "$TMP_PATH/lib/libzygisk.so"
 fi
 
 [ "$DEBUG" = true ] && export RUST_BACKTRACE=1
 
-if [ -f $MODDIR/bin/zygisk-ptrace64 ];then
-$MODDIR/bin/zygisk-ptrace64 monitor &
-elif [ -f $MODDIR/bin/zygisk-ptrace32 ];then
-$MODDIR/bin/zygisk-ptrace32 monitor &
+# ── Zygote monitor ────────────────────────────────────────────────────────────
+if [ -f "$MODDIR/bin/zygisk-ptrace64" ]; then
+  "$MODDIR/bin/zygisk-ptrace64" monitor &
+elif [ -f "$MODDIR/bin/zygisk-ptrace32" ]; then
+  "$MODDIR/bin/zygisk-ptrace32" monitor &
 fi


### PR DESCRIPTION
## Summary

- Standardise all module shell scripts with consistent banner-style headers
- Quote all variable expansions (fixes potential word-splitting on paths with spaces)
- Reformat `action.sh` status card with box-drawing characters for readability
- Fix indentation (tabs → spaces) in `action.sh` sleep block