### PR TITLE
docs: sync zh-CN, zh-TW, ja READMEs with English overhaul

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,64 +1,103 @@
 <div align="center">
 
-<img src="assets/tux.png" alt="OnyxZygisk" width="96">
+<img src="assets/tux.png" alt="OnyxZygisk" width="128">
 
 # OnyxZygisk
 
-**APatch** と **KernelSU** 向けの **ptrace ベースの Zygisk 実装** —— 組み込みの **WebUI** と **FN（Functional Node）モジュール**を備えています。
+**あらゆる Root でそのまま動く Zygisk ランタイム。**
+
+ptrace ベースの Zygisk 実装。WebUI 内蔵、ホットスワップ対応の FN モジュール、高度な DenyList を搭載。カーネルモジュール不要。
+
+[![Telegram](https://img.shields.io/badge/Telegram-OnyxZygisk-2CA5E0?logo=telegram&logoColor=white)](https://t.me/OnyxZygisk)
+[![Release](https://img.shields.io/github/v/release/OnyxZygisk/OnyxZygisk?label=最新版&color=brightgreen)](https://github.com/OnyxZygisk/OnyxZygisk/releases/latest)
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
 
 [English](README.md) · [简体中文](README.zh-CN.md) · [繁體中文](README.zh-TW.md) · **日本語**
-
-[![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](LICENSE)
 
 </div>
 
 ---
 
-## 特長
+## なぜ OnyxZygisk？
 
-- **組み込み WebUI** —— `webroot/` から配信される複数ページの管理パネル。KernelSU / APatch Manager / MMRL から直接開けます。ダッシュボード、モジュール一覧、FN 管理、logcat ビューア、APatch ページを備え、ライト / ダーク / AMOLED テーマと多言語に対応。詳細は [docs/WEBUI.md](docs/WEBUI.md)。
-- **FN（Functional Node）モジュール** —— Zygisk コアの上で動く、宣言的・スコープ指定・ホットスワップ可能な拡張ユニット。スクリプトノードとネイティブノードがあり、再起動なしで有効化/無効化できます。詳細は [docs/FN.md](docs/FN.md)。
-- **APatch 優先対応** —— `apd` の検出、実 CSV の `package_config` 解析とアトミック書き込み、既知の root オーバーレイ元を網羅したクリーンな名前空間のアンマウント。詳細は [docs/APATCH.md](docs/APATCH.md)。
-- **高度なステルス** —— root やモジュールの痕跡を検出しようとするアプリから、それらを隠す高度な DenyList。
+### Root 方式を問わない
 
-## DenyList について
+**APatch**、**KernelSU**（LKM 遅延ロードを含む）、**Magisk** にそのまま対応。Root 方式を変えても Zygisk を変える必要はありません — ひとつのモジュールですべてカバー。
 
-最近の systemless root は、システムパーティションを直接変更せず overlay [マウント](https://man7.org/linux/man-pages/man8/mount.8.html)を重ねて動作します。DenyList は各アプリの[マウント名前空間](https://man7.org/linux/man-pages/man7/mount_namespaces.7.html)を制御して、それらの変更を隠します:
+### 再起動不要のワークフロー
 
-| アプリの状態 | マウント名前空間 | 用途 |
-| :--- | :--- | :--- |
-| **Root 付与** | Root + モジュールのマウント | 完全な root を必要とする信頼済みアプリ(高機能ファイラーなど)。 |
-| **DenyList 対象** | クリーン・未変更 | root 検出を行うアプリ向けの、まっさらな環境。 |
+- **ホットプラグ** — Zygisk モジュールの有効化・無効化に再起動不要。
+- **FN モジュール** — 宣言的・スコープ指定・ホットスワップ可能な拡張ノード。次のアプリ起動時にすぐ反映されます。[詳細 →](docs/FN.md)
 
-クリーンな名前空間を作る 2 つの戦略:
+### 内蔵 WebUI
 
-1. **zygote から直接アンマウント(主戦略)** —— アプリが specialize される*前*に、zygote から root の痕跡を直接アンマウントします。あるモジュールが重要なシステムリソース(例: `/product` のオーバーレイ)を提供している場合は、zygote のクラッシュを避けるため安全チェックにより中止されます。
-2. **名前空間の切り替え(フォールバック)** —— fork 後に `setns` でアプリをキャッシュ済みの完全にクリーンなマウント名前空間へ移します。
+Vue 3 + Vite + TypeScript で構築されたフル機能のコントロールパネル。KernelSU / APatch Manager / MMRL がローカルで読み取り — ネットワークポート不要、サーバープロセス不要。ダッシュボード、モジュール一覧、FN 管理、logcat ビューア。ライト / ダーク / AMOLED テーマ対応。[詳細 →](docs/WEBUI.md)
 
-## 設定
+### 高度なステルス
 
-- **APatch / KernelSU:** 対象アプリで **`Umount modules`** を有効にします。
-- **Magisk:** **`Configure DenyList`** を使用します。Magisk 自身の **`Enforce DenyList`** は *オフ* のままに —— OnyxZygisk の隠蔽と競合することがあります。
+二層構造の DenyList で、検出強化アプリから Root を完全に隠蔽：
 
-## ソースからのビルド
+| 戦略 | 仕組み |
+| :--- | :--- |
+| **Zygote アンマウント**（主戦略） | アプリプロセスが specialize される*前*に、zygote から root・モジュールのマウントを剥離。 |
+| **名前空間切り替え**（フォールバック） | fork 後、`setns` でアプリをキャッシュ済みの完全クリーンなマウント名前空間へ移動。 |
+
+`/proc/self/maps` に痕跡なし、マウントポイントの漏洩なし、ファイルディスクリプタの残留なし。
+
+### ユーザー空間のみ、カーネルモジュール不要
+
+純粋な ptrace インジェクション — カスタムカーネルモジュールのビルド・保守・カーネル更新時の修正が一切不要。`PTRACE_SEIZE` 対応のすべてのカーネルで動作します。
+
+---
+
+## クイックスタート
+
+### インストール
+
+[最新リリース](https://github.com/OnyxZygisk/OnyxZygisk/releases/latest)から zip をダウンロードし、Root マネージャー（APatch / KernelSU / Magisk）でフラッシュして再起動。
+
+### DenyList の設定
+
+| Root 方式 | 設定場所 |
+| :--- | :--- |
+| **APatch / KernelSU** | 対象アプリで **Umount modules** を有効化 |
+| **Magisk** | **Configure DenyList**（Magisk 自身の「Enforce DenyList」は**オフ**のまま） |
+
+### WebUI を開く
+
+KernelSU Manager、APatch Manager、または MMRL でモジュールページを開き、**WebUI** をタップ。
+
+---
+
+## ソースからビルド
 
 ```sh
-git clone https://github.com/GG-Linux/OnyxZygisk.git
+git clone https://github.com/OnyxZygisk/OnyxZygisk.git
 cd OnyxZygisk
 ./gradlew :module:zipRelease
 ```
 
-フラッシュ可能な zip は `module/build/outputs/module/` に出力されます。
+フラッシュ可能な zip は `module/build/outputs/release/` に出力されます。
+
+---
+
+## コミュニティ
+
+[![Telegram Channel](https://img.shields.io/badge/Telegram-OnyxZygisk-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/OnyxZygisk)
+
+Telegram チャンネルに参加して、リリース情報・ディスカッション・サポートを受け取りましょう。
+
+---
 
 ## クレジット
 
-OnyxZygisk は、その土台となり着想を与えてくれたプロジェクトの上に成り立っています:
+OnyxZygisk は以下のプロジェクトの上に構築され、そこから着想を得ています：
 
-- **Zygisk API** —— [topjohnwu](https://github.com/topjohnwu) / [Magisk](https://github.com/topjohnwu/Magisk)
-- **Zygisk Next**(スタンドアロンの ptrace 実装)—— [Dr-TSNG](https://github.com/Dr-TSNG/ZygiskNext)
-- **NeoZygisk**(OnyxZygisk はこれをベースにしています)—— [JingMatrix](https://github.com/JingMatrix/NeoZygisk)
-- **OnyxZygisk** —— Sai, Matsuzaka Yuki および[コントリビューター](https://github.com/GG-Linux/OnyxZygisk/graphs/contributors)
+- **Zygisk API** — [topjohnwu](https://github.com/topjohnwu) / [Magisk](https://github.com/topjohnwu/Magisk)
+- **Zygisk Next** — [Dr-TSNG](https://github.com/Dr-TSNG/ZygiskNext)
+- **NeoZygisk** — [JingMatrix](https://github.com/JingMatrix/NeoZygisk)
+- **OnyxZygisk** — Sai, Matsuzaka Yuki および[コントリビューター](https://github.com/OnyxZygisk/OnyxZygisk/graphs/contributors)
 
 ## ライセンス
 
-[AGPL-3.0](LICENSE)。OnyxZygisk は NeoZygisk の派生であり、同じライセンスと表示を維持します。
+[AGPL-3.0](LICENSE)。OnyxZygisk は NeoZygisk (GPL-3.0) の下流であり、CSOLoader (AGPL-3.0) をインプロセスのカスタムモジュールローダーとして統合しています。GPL-3.0 §13 に基づき、結合著作物は AGPL-3.0 で頒布されます。上流の GPL-3.0 通知は保持されています — [NOTICE.md](NOTICE.md) を参照してください。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,64 +1,103 @@
 <div align="center">
 
-<img src="assets/tux.png" alt="OnyxZygisk" width="96">
+<img src="assets/tux.png" alt="OnyxZygisk" width="128">
 
 # OnyxZygisk
 
-面向 **APatch** 与 **KernelSU** 的**基于 ptrace 的 Zygisk 实现** —— 内置 **WebUI** 与 **FN(Functional Node)模块**。
+**开箱即用的 Zygisk 运行时 —— 全 Root 方案通用。**
+
+基于 ptrace 的 Zygisk 实现，内置 WebUI、可热插拔的 FN 模块和进阶 DenyList。无需内核模块。
+
+[![Telegram](https://img.shields.io/badge/Telegram-OnyxZygisk-2CA5E0?logo=telegram&logoColor=white)](https://t.me/OnyxZygisk)
+[![Release](https://img.shields.io/github/v/release/OnyxZygisk/OnyxZygisk?label=最新版&color=brightgreen)](https://github.com/OnyxZygisk/OnyxZygisk/releases/latest)
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
 
 [English](README.md) · **简体中文** · [繁體中文](README.zh-TW.md) · [日本語](README.ja.md)
-
-[![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](LICENSE)
 
 </div>
 
 ---
 
-## 亮点
+## 为什么选择 OnyxZygisk？
 
-- **内置 WebUI** —— 基于 **Vue 3 + Vite + TypeScript** 的控制面板，以静态文件随 `webroot/` 提供，可在 KernelSU / APatch Manager / MMRL 中直接打开。包含仪表盘、模块列表、FN 管理、logcat 查看器。支持浅色 / 深色 / 纯黑主题与多语言。详见 [docs/WEBUI.md](docs/WEBUI.md)。
-- **FN(Functional Node)模块** —— 位于 Zygisk 核心之上的声明式、按作用域、可热插拔的扩展单元:脚本节点与原生节点,无需重启即可启用/禁用。详见 [docs/FN.md](docs/FN.md)。
-- **APatch 优先适配** —— `apd` 检测、真实 CSV 的 `package_config` 解析与原子写入、覆盖已知 root overlay 来源的干净命名空间卸载。详见 [docs/APATCH.md](docs/APATCH.md)。
-- **进阶隐藏** —— 精细的 DenyList,对进行 root 检测的应用隐藏 root 与模块痕迹。
+### Root 方案无关
 
-## DenyList 说明
+开箱兼容 **APatch**、**KernelSU**（含 LKM 延迟加载）和 **Magisk**。更换 Root 方案无需更换 Zygisk —— 一个模块全部搞定。
 
-现代 systemless root 通过叠加 overlay [挂载](https://man7.org/linux/man-pages/man8/mount.8.html)工作,而非直接改动系统分区。DenyList 通过控制每个应用的[挂载命名空间](https://man7.org/linux/man-pages/man7/mount_namespaces.7.html)来隐藏这些改动:
+### 零重启工作流
 
-| 应用状态 | 挂载命名空间 | 适用场景 |
-| :--- | :--- | :--- |
-| **已授予 Root** | Root + 模块挂载 | 需要完整 root 的可信应用(如高级文件管理器)。 |
-| **在 DenyList** | 干净、未修改 | 为进行 root 检测的应用提供纯净环境。 |
+- **热插拔** —— 启用或禁用 Zygisk 模块无需重启。
+- **FN 模块** —— 声明式、按作用域、可热插拔的扩展节点，下次应用启动即刻生效。[了解更多 →](docs/FN.md)
 
-产生干净命名空间的两种策略:
+### 内置 WebUI
 
-1. **直接从 zygote 卸载(主策略)** —— 在应用被 specialize *之前*,直接从 zygote 卸载 root 痕迹。若某模块提供关键系统资源(如 `/product` 的 overlay),安全检查会中止此操作以免 zygote 崩溃。
-2. **命名空间切换(回退策略)** —— fork 之后,用 `setns` 将应用切换进一个缓存好的、完全干净的挂载命名空间。
+基于 Vue 3 + Vite + TypeScript 构建的完整控制面板，由 KernelSU / APatch Manager / MMRL 本地读取 —— 无需网络端口，无需服务进程。仪表盘、模块列表、FN 管理、logcat 查看器。浅色 / 深色 / 纯黑主题。[了解更多 →](docs/WEBUI.md)
 
-## 配置
+### 进阶隐藏
 
-- **APatch / KernelSU:** 为目标应用启用 **`卸载模块 / Umount modules`**。
-- **Magisk:** 使用 **`配置 DenyList`**。请**关闭** Magisk 自带的 **`强制 DenyList`** —— 它可能与 OnyxZygisk 的隐藏机制冲突。
+双层 DenyList，让 Root 痕迹对检测类应用完全不可见：
+
+| 策略 | 工作原理 |
+| :--- | :--- |
+| **Zygote 卸载**（主策略） | 在应用进程 specialize *之前*，从 zygote 剥离 root 与模块挂载。 |
+| **命名空间切换**（回退） | fork 后通过 `setns` 将应用移入缓存好的、完全干净的挂载命名空间。 |
+
+`/proc/self/maps` 无痕迹、无泄漏的挂载点、无残留的文件描述符。
+
+### 纯用户态，无内核模块
+
+纯 ptrace 注入 —— 无需构建、维护或在内核更新后修复自定义内核模块。支持所有启用 `PTRACE_SEIZE` 的内核。
+
+---
+
+## 快速上手
+
+### 安装
+
+从[最新 Release](https://github.com/OnyxZygisk/OnyxZygisk/releases/latest) 下载 zip，在 Root 管理器（APatch / KernelSU / Magisk）中刷入并重启。
+
+### 配置 DenyList
+
+| Root 方案 | 操作位置 |
+| :--- | :--- |
+| **APatch / KernelSU** | 为目标应用启用 **卸载模块** |
+| **Magisk** | **配置 DenyList**（保持 Magisk 自带的"强制 DenyList"**关闭**） |
+
+### 打开 WebUI
+
+在 KernelSU Manager、APatch Manager 或 MMRL 中打开模块页面，点击 **WebUI**。
+
+---
 
 ## 从源码构建
 
 ```sh
-git clone https://github.com/GG-Linux/OnyxZygisk.git
+git clone https://github.com/OnyxZygisk/OnyxZygisk.git
 cd OnyxZygisk
 ./gradlew :module:zipRelease
 ```
 
-可刷入的 zip 输出到 `module/build/outputs/module/`。
+可刷入的 zip 输出到 `module/build/outputs/release/`。
+
+---
+
+## 社区
+
+[![Telegram Channel](https://img.shields.io/badge/Telegram-OnyxZygisk-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/OnyxZygisk)
+
+加入 Telegram 频道，获取版本发布公告、讨论与技术支持。
+
+---
 
 ## 致谢
 
-OnyxZygisk 站在它所构建于、所受启发的项目的肩膀上:
+OnyxZygisk 基于以下项目构建并受其启发：
 
 - **Zygisk API** —— [topjohnwu](https://github.com/topjohnwu) / [Magisk](https://github.com/topjohnwu/Magisk)
-- **Zygisk Next**(独立 ptrace 实现)—— [Dr-TSNG](https://github.com/Dr-TSNG/ZygiskNext)
-- **NeoZygisk**(OnyxZygisk 基于此)—— [JingMatrix](https://github.com/JingMatrix/NeoZygisk)
-- **OnyxZygisk** —— Sai, Matsuzaka Yuki 与[贡献者们](https://github.com/GG-Linux/OnyxZygisk/graphs/contributors)
+- **Zygisk Next** —— [Dr-TSNG](https://github.com/Dr-TSNG/ZygiskNext)
+- **NeoZygisk** —— [JingMatrix](https://github.com/JingMatrix/NeoZygisk)
+- **OnyxZygisk** —— Sai, Matsuzaka Yuki 与[贡献者们](https://github.com/OnyxZygisk/OnyxZygisk/graphs/contributors)
 
 ## 许可证
 
-[AGPL-3.0](LICENSE)。OnyxZygisk 是 NeoZygisk 的下游,沿用相同的许可证与声明。
+[AGPL-3.0](LICENSE)。OnyxZygisk 是 NeoZygisk (GPL-3.0) 的下游，集成了 CSOLoader (AGPL-3.0) 作为进程内自定义模块加载器；依据 GPL-3.0 §13，组合作品以 AGPL-3.0 发布。上游 GPL-3.0 声明保留 —— 详见 [NOTICE.md](NOTICE.md)。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,64 +1,103 @@
 <div align="center">
 
-<img src="assets/tux.png" alt="OnyxZygisk" width="96">
+<img src="assets/tux.png" alt="OnyxZygisk" width="128">
 
 # OnyxZygisk
 
-面向 **APatch** 與 **KernelSU** 的**基於 ptrace 的 Zygisk 實作** —— 內建 **WebUI** 與 **FN(Functional Node)模組**。
+**開箱即用的 Zygisk 執行環境 —— 全 Root 方案通用。**
+
+基於 ptrace 的 Zygisk 實作，內建 WebUI、可熱抽換的 FN 模組和進階 DenyList。無需核心模組。
+
+[![Telegram](https://img.shields.io/badge/Telegram-OnyxZygisk-2CA5E0?logo=telegram&logoColor=white)](https://t.me/OnyxZygisk)
+[![Release](https://img.shields.io/github/v/release/OnyxZygisk/OnyxZygisk?label=最新版&color=brightgreen)](https://github.com/OnyxZygisk/OnyxZygisk/releases/latest)
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
 
 [English](README.md) · [简体中文](README.zh-CN.md) · **繁體中文** · [日本語](README.ja.md)
-
-[![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](LICENSE)
 
 </div>
 
 ---
 
-## 亮點
+## 為什麼選擇 OnyxZygisk？
 
-- **內建 WebUI** —— 由 `webroot/` 提供的多頁控制面板,可在 KernelSU / APatch Manager / MMRL 中直接開啟。包含儀表板、模組清單、FN 管理、logcat 檢視器,以及 APatch 頁。支援淺色 / 深色 / 純黑主題與多語言。詳見 [docs/WEBUI.md](docs/WEBUI.md)。
-- **FN(Functional Node)模組** —— 位於 Zygisk 核心之上的宣告式、依作用域、可熱抽換的擴充單元:指令碼節點與原生節點,無需重新開機即可啟用/停用。詳見 [docs/FN.md](docs/FN.md)。
-- **APatch 優先適配** —— `apd` 偵測、真實 CSV 的 `package_config` 解析與原子寫入、涵蓋已知 root overlay 來源的乾淨命名空間卸載。詳見 [docs/APATCH.md](docs/APATCH.md)。
-- **進階隱藏** —— 精細的 DenyList,對進行 root 偵測的應用隱藏 root 與模組痕跡。
+### Root 方案無關
 
-## DenyList 說明
+開箱相容 **APatch**、**KernelSU**（含 LKM 延遲載入）和 **Magisk**。更換 Root 方案無需更換 Zygisk —— 一個模組全部搞定。
 
-現代 systemless root 透過堆疊 overlay [掛載](https://man7.org/linux/man-pages/man8/mount.8.html)運作,而非直接改動系統分割區。DenyList 透過控制每個應用的[掛載命名空間](https://man7.org/linux/man-pages/man7/mount_namespaces.7.html)來隱藏這些改動:
+### 零重啟工作流
 
-| 應用狀態 | 掛載命名空間 | 適用情境 |
-| :--- | :--- | :--- |
-| **已授予 Root** | Root + 模組掛載 | 需要完整 root 的可信應用(如進階檔案管理器)。 |
-| **在 DenyList** | 乾淨、未修改 | 為進行 root 偵測的應用提供純淨環境。 |
+- **熱插拔** —— 啟用或停用 Zygisk 模組無需重新開機。
+- **FN 模組** —— 宣告式、依作用域、可熱抽換的擴充節點，下次應用啟動即刻生效。[了解更多 →](docs/FN.md)
 
-產生乾淨命名空間的兩種策略:
+### 內建 WebUI
 
-1. **直接從 zygote 卸載(主策略)** —— 在應用被 specialize *之前*,直接從 zygote 卸載 root 痕跡。若某模組提供關鍵系統資源(如 `/product` 的 overlay),安全檢查會中止此操作以免 zygote 崩潰。
-2. **命名空間切換(回退策略)** —— fork 之後,以 `setns` 將應用切換進一個快取好的、完全乾淨的掛載命名空間。
+基於 Vue 3 + Vite + TypeScript 建置的完整控制面板，由 KernelSU / APatch Manager / MMRL 本機讀取 —— 無需網路連接埠，無需伺服器行程。儀表板、模組清單、FN 管理、logcat 檢視器。淺色 / 深色 / 純黑佈景主題。[了解更多 →](docs/WEBUI.md)
 
-## 設定
+### 進階隱藏
 
-- **APatch / KernelSU:** 為目標應用啟用 **`卸載模組 / Umount modules`**。
-- **Magisk:** 使用 **`設定 DenyList`**。請**關閉** Magisk 內建的 **`強制 DenyList`** —— 它可能與 OnyxZygisk 的隱藏機制衝突。
+雙層 DenyList，讓 Root 痕跡對偵測類應用完全不可見：
+
+| 策略 | 工作原理 |
+| :--- | :--- |
+| **Zygote 卸載**（主策略） | 在應用行程 specialize *之前*，從 zygote 剝離 root 與模組掛載。 |
+| **命名空間切換**（回退） | fork 後透過 `setns` 將應用移入快取好的、完全乾淨的掛載命名空間。 |
+
+`/proc/self/maps` 無痕跡、無洩漏的掛載點、無殘留的檔案描述符。
+
+### 純使用者態，無核心模組
+
+純 ptrace 注入 —— 無需建置、維護或在核心更新後修復自訂核心模組。支援所有啟用 `PTRACE_SEIZE` 的核心。
+
+---
+
+## 快速上手
+
+### 安裝
+
+從[最新 Release](https://github.com/OnyxZygisk/OnyxZygisk/releases/latest) 下載 zip，在 Root 管理器（APatch / KernelSU / Magisk）中刷入並重新開機。
+
+### 設定 DenyList
+
+| Root 方案 | 操作位置 |
+| :--- | :--- |
+| **APatch / KernelSU** | 為目標應用啟用 **卸載模組** |
+| **Magisk** | **設定 DenyList**（保持 Magisk 內建的「強制 DenyList」**關閉**） |
+
+### 開啟 WebUI
+
+在 KernelSU Manager、APatch Manager 或 MMRL 中開啟模組頁面，點選 **WebUI**。
+
+---
 
 ## 從原始碼建置
 
 ```sh
-git clone https://github.com/GG-Linux/OnyxZygisk.git
+git clone https://github.com/OnyxZygisk/OnyxZygisk.git
 cd OnyxZygisk
 ./gradlew :module:zipRelease
 ```
 
-可刷入的 zip 會輸出到 `module/build/outputs/module/`。
+可刷入的 zip 輸出到 `module/build/outputs/release/`。
+
+---
+
+## 社群
+
+[![Telegram Channel](https://img.shields.io/badge/Telegram-OnyxZygisk-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/OnyxZygisk)
+
+加入 Telegram 頻道，取得版本發佈公告、討論與技術支援。
+
+---
 
 ## 致謝
 
-OnyxZygisk 站在它所建置於、所受啟發的專案的肩膀上:
+OnyxZygisk 基於以下專案建置並受其啟發：
 
 - **Zygisk API** —— [topjohnwu](https://github.com/topjohnwu) / [Magisk](https://github.com/topjohnwu/Magisk)
-- **Zygisk Next**(獨立 ptrace 實作)—— [Dr-TSNG](https://github.com/Dr-TSNG/ZygiskNext)
-- **NeoZygisk**(OnyxZygisk 基於此)—— [JingMatrix](https://github.com/JingMatrix/NeoZygisk)
-- **OnyxZygisk** —— Sai, Matsuzaka Yuki 與[貢獻者們](https://github.com/GG-Linux/OnyxZygisk/graphs/contributors)
+- **Zygisk Next** —— [Dr-TSNG](https://github.com/Dr-TSNG/ZygiskNext)
+- **NeoZygisk** —— [JingMatrix](https://github.com/JingMatrix/NeoZygisk)
+- **OnyxZygisk** —— Sai, Matsuzaka Yuki 與[貢獻者們](https://github.com/OnyxZygisk/OnyxZygisk/graphs/contributors)
 
 ## 授權條款
 
-[AGPL-3.0](LICENSE)。OnyxZygisk 是 NeoZygisk 的下游,沿用相同的授權條款與聲明。
+[AGPL-3.0](LICENSE)。OnyxZygisk 是 NeoZygisk (GPL-3.0) 的下游，整合了 CSOLoader (AGPL-3.0) 作為行程內自訂模組載入器；依據 GPL-3.0 §13，組合作品以 AGPL-3.0 發佈。上游 GPL-3.0 聲明保留 —— 詳見 [NOTICE.md](NOTICE.md)。


### PR DESCRIPTION
## Summary

Sync all three translation READMEs with the English overhaul from #48:

- **zh-CN** (简体中文), **zh-TW** (繁體中文), **ja** (日本語)
- Same five-section feature layout, quick-start guide, Telegram badge, community section
- Updated license text (AGPL-3.0 full explanation) and build output path