### PR TITLE
release: v1.0.6 — cold-reboot hot-plug, remote CSO loader, cross-boot…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,11 @@ val gitCommitHash = "git rev-parse --verify --short HEAD".execute()
 
 val moduleId by extra("onyxzygisk")
 val moduleName by extra("OnyxZygisk")
-val verName by extra("v1.0.5")
-val verCode by extra(gitCommitCount)
+// Hot-plug restart-loop hotfix. Keep this build distinguishable from the
+// earlier v1.0.5-368 archives: root-manager/WebView caches and repeated local
+// filenames made it too easy to flash an older binary while testing fixes.
+val verName by extra("v1.0.6")
+val verCode by extra(gitCommitCount + 1)
 val commitHash by extra(gitCommitHash)
 val minAPatchVersion by extra(10762)
 val minKsuVersion by extra(10940)

--- a/loader/src/injector/entry.cpp
+++ b/loader/src/injector/entry.cpp
@@ -7,7 +7,7 @@
 using namespace std;
 
 extern "C" [[gnu::visibility("default")]]
-void entry(void* addr, size_t size, const char* path) {
+void entry(void* addr, size_t size, const char* path, bool custom_loaded) {
     LOGI("zygisk library injected, version %s", ZKSU_VERSION);
 
     zygiskd::Init(path);
@@ -17,7 +17,7 @@ void entry(void* addr, size_t size, const char* path) {
         return;
     }
 
-    hook_entry(addr, size);
+    hook_entry(addr, size, custom_loaded);
     send_seccomp_event_if_needed();
 }
 

--- a/loader/src/injector/hook.cpp
+++ b/loader/src/injector/hook.cpp
@@ -440,10 +440,15 @@ void HookContext::restore_zygote_hook(JNIEnv *env) {
 
 // -----------------------------------------------------------------
 
-void hook_entry(void *start_addr, size_t block_size) {
+void hook_entry(void *start_addr, size_t block_size, bool custom_loaded) {
     g_hook = new HookContext(start_addr, block_size);
     g_hook->hook_plt();
-    clean_linker_trace(zygiskd::GetTmpPath().data(), 1, 0, true);
+    // A custom-mapped image never entered bionic's solist. Trying to remove it
+    // would corrupt the linker's load counters and can dereference a record
+    // that does not exist. Path-based dlopen still needs the original cleanup.
+    if (!custom_loaded) {
+        clean_linker_trace(zygiskd::GetTmpPath().data(), 1, 0, true);
+    }
 }
 
 void hookJniNativeMethods(JNIEnv *env, const char *clz, JNINativeMethod *methods, int numMethods) {

--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -454,15 +454,22 @@ void ZygiskContext::app_specialize_post() {
 // thread pulling modules and calling preServerSpecialize) and is a dead end:
 // device logs proved it deterministically SIGSEGVs system_server the instant
 // the load runs. A framework module (LSPosed) only activates when it is loaded
-// at system_server's *fork/specialize* — never mid-life. So a module
-// hot-plugged after boot is activated by re-forking system_server once (a
-// controlled ~15s framework restart, not a full reboot); the daemon does that
-// after swapping the module into the active directory. See
-// zygiskd::activate_staged_module.
+// at system_server's *fork/specialize* — never mid-life. Re-forking
+// system_server in place (kill + respawn) was tried next and proved unsafe:
+// a module that misbehaves on the soft-restarted framework makes zygote/netd
+// restart repeatedly, which Android init escalates into a hard reboot —
+// looping the device. So a module hot-plugged after boot is activated by
+// rebooting the device once; the daemon does that after swapping the module
+// into the active directory. See zygiskd::reboot_device_to_activate.
 
 void ZygiskContext::server_specialize_pre() {
-    run_modules_pre();
+    // Notify the daemon BEFORE loading any module. The daemon's hot-plug
+    // circuit breaker keys off this heartbeat: if a freshly hot-plugged
+    // module crashes or hangs system_server while being loaded below, the
+    // restart guard would otherwise stay armed forever and the breaker
+    // could never unplug the offending module.
     zygiskd::SystemServerStarted();
+    run_modules_pre();
 }
 
 void ZygiskContext::server_specialize_post() { run_modules_post(); }

--- a/loader/src/injector/zygisk.hpp
+++ b/loader/src/injector/zygisk.hpp
@@ -18,7 +18,7 @@ struct mount_info {
     std::string raw_info;
 };
 
-void hook_entry(void *start_addr, size_t block_size);
+void hook_entry(void *start_addr, size_t block_size, bool custom_loaded);
 
 void hookJniNativeMethods(JNIEnv *env, const char *clz, JNINativeMethod *methods, int numMethods);
 

--- a/loader/src/ptracer/main.cpp
+++ b/loader/src/ptracer/main.cpp
@@ -24,6 +24,18 @@ const char *const kWorkDirectory = WORK_DIRECTORY;
 void init_monitor() {
     LOGI("OnyxZygisk %s", ZKSU_VERSION);
 
+    // Boot-loop fail-safe: zygisk-init.sh latches this flag after several
+    // consecutive boots that never proved healthy (service.sh's health
+    // witness never got to clear the counter). Running with no injection at
+    // all is better than keeping the device in a reboot cycle; the user
+    // re-enables by removing the flag file.
+    std::string failsafe_flag = zygiskd::GetTmpPath() + "/injection_disabled";
+    if (access(failsafe_flag.c_str(), F_OK) == 0) {
+        LOGE("Boot-loop fail-safe latched (%s): injection disabled. Fix the offending module, then remove the flag to re-enable.",
+             failsafe_flag.c_str());
+        return;
+    }
+
     // All logic is now encapsulated in an AppMonitor instance.
     AppMonitor monitor;
     if (!monitor.prepare_environment()) {

--- a/loader/src/ptracer/ptracer.cpp
+++ b/loader/src/ptracer/ptracer.cpp
@@ -18,6 +18,7 @@
 
 #include "daemon.hpp"
 #include "logging.hpp"
+#include "remote_csoloader.hpp"
 #include "utils.hpp"
 
 /**
@@ -216,16 +217,23 @@ bool inject_on_main(int pid, const char *lib_path) {
         return false;
     };
 
-    // Remotely call dlopen(lib_path, RTLD_NOW).
-    //
-    // This deliberately loads by PATH rather than from a memfd via
-    // android_dlopen_ext(ANDROID_DLEXT_USE_LIBRARY_FD). An fd-based load was
-    // tried and reverted: handing the target an fd requires it to open
-    // /proc/<tracer>/fd/<n>, which the kernel gates behind ptrace_may_access()
-    // plus SELinux and which simply fails on some devices; and any fd left
-    // open in zygote is fatal, because zygote validates every open descriptor
-    // against an allowlist on each fork and aborts the process outright on an
-    // unrecognized one ("Not allowlisted ... /memfd:libzygisk.so").
+    if (libc_return_addr == nullptr) {
+        return abort_injection("could not find a safe libc return trap in the target process");
+    }
+
+    // Where the injected library lands and the address of its `entry` symbol;
+    // both load paths below fill these in.
+    void *start_addr = nullptr;
+    size_t block_size = 0;
+    uintptr_t injector_entry = 0;
+    bool custom_loaded = false;
+
+    // --- Primary load: remote dlopen() through the system linker ---
+    // Let bionic perform relocations and C++ constructor ordering whenever it
+    // accepts the path.  Besides being simpler, this is important for zygote
+    // safety: a failed hand-written constructor sequence may already have
+    // mutated global state before it faults, so it must never be attempted
+    // speculatively on devices where the normal linker works.
     LOGV("executing remote call to dlopen(\"%s\")", lib_path);
     auto dlopen_addr = find_func_addr(local_map, map, "libdl.so", "dlopen");
     if (dlopen_addr == nullptr) {
@@ -238,95 +246,123 @@ bool inject_on_main(int pid, const char *lib_path) {
     }
     args.push_back((long) remote_lib_path);
     args.push_back((long) RTLD_NOW);
-    auto remote_handle =
-        remote_call(pid, regs, (uintptr_t) dlopen_addr, (uintptr_t) libc_return_addr, args);
+    bool dlopen_call_succeeded = false;
+    auto remote_handle = remote_call(pid, regs, (uintptr_t) dlopen_addr,
+                                     (uintptr_t) libc_return_addr, args,
+                                     &dlopen_call_succeeded);
 
-    if (remote_handle == 0) {
-        LOGE("remote call to dlopen failed, retrieving error message with dlerror");
+    // A signal or unexpected ptrace stop while running the system linker is not
+    // a namespace rejection.  The tracee may be partially modified, so abort
+    // instead of trying another loader in the same zygote.
+    if (!dlopen_call_succeeded) {
+        return abort_injection("remote dlopen did not return cleanly");
+    }
 
-        // Probe whether the target can even see the file. dlopen() reports a
-        // bare "library ... not found" both when the path is invisible to the
-        // target (mount namespace / SELinux) and when the linker's namespace
-        // rules reject an otherwise-readable path -- this distinguishes them.
+    if (remote_handle != 0) {
+        LOGI("successfully loaded library via remote dlopen, handle: 0x%" PRIxPTR,
+             remote_handle);
+
+        LOGV("executing remote call to dlsym to find the 'entry' symbol");
+        auto dlsym_addr = find_func_addr(local_map, map, "libdl.so", "dlsym");
+        if (dlsym_addr == nullptr) {
+            return abort_injection("could not find address of dlsym in the target process");
+        }
+        args.clear();
+        auto remote_entry_str = push_string(pid, regs, "entry");
+        args.push_back(remote_handle);
+        args.push_back((long) remote_entry_str);
+        bool dlsym_call_succeeded = false;
+        injector_entry = remote_call(pid, regs, (uintptr_t) dlsym_addr,
+                                     (uintptr_t) libc_return_addr, args,
+                                     &dlsym_call_succeeded);
+        if (!dlsym_call_succeeded || injector_entry == 0) {
+            return abort_injection(
+                "dlsym failed to find the 'entry' symbol in the injected library");
+        }
+        LOGI("found injector entry point at address 0x%" PRIxPTR, injector_entry);
+
+        map = MapInfo::Scan(std::to_string(pid));
+        for (const auto &info : map) {
+            if (info.path.find("libzygisk.so") != std::string::npos) {
+                if (start_addr == nullptr) start_addr = (void *) info.start;
+                block_size += (info.end - info.start);
+            }
+        }
+        LOGV("found injected library mapped from %p with total size %zu", start_addr,
+             block_size);
+    } else {
+        // dlopen returned normally but rejected the path.  This is the narrow
+        // case the custom loader exists for (notably some KernelSU LKM linker
+        // namespaces), so collect diagnostics and then use it as a fallback.
+        LOGW("remote dlopen rejected the library; trying the custom loader fallback");
         if (auto access_addr = find_func_addr(local_map, map, "libc.so", "access");
             access_addr != nullptr) {
             args.clear();
             args.push_back((long) remote_lib_path);
             args.push_back(R_OK);
-            auto access_ret =
-                remote_call(pid, regs, (uintptr_t) access_addr, (uintptr_t) libc_return_addr, args);
-            LOGE("target-side access(\"%s\", R_OK) returned %ld (0 = readable by target)", lib_path,
-                 (long) access_ret);
+            bool access_call_succeeded = false;
+            auto access_ret = remote_call(pid, regs, (uintptr_t) access_addr,
+                                          (uintptr_t) libc_return_addr, args,
+                                          &access_call_succeeded);
+            if (access_call_succeeded) {
+                LOGW("target-side access(\"%s\", R_OK) returned %ld (0 = readable)",
+                     lib_path, (long) access_ret);
+            }
         }
 
-        auto dlerror_addr = find_func_addr(local_map, map, "libdl.so", "dlerror");
-        if (dlerror_addr == nullptr) {
-            return abort_injection("could not find address of dlerror; cannot retrieve error string");
+        if (auto dlerror_addr = find_func_addr(local_map, map, "libdl.so", "dlerror");
+            dlerror_addr != nullptr) {
+            args.clear();
+            bool dlerror_call_succeeded = false;
+            auto dlerror_str_addr = remote_call(pid, regs, (uintptr_t) dlerror_addr,
+                                                (uintptr_t) libc_return_addr, args,
+                                                &dlerror_call_succeeded);
+            if (dlerror_call_succeeded && dlerror_str_addr != 0) {
+                if (auto strlen_addr = find_func_addr(local_map, map, "libc.so", "strlen");
+                    strlen_addr != nullptr) {
+                    args.clear();
+                    args.push_back(dlerror_str_addr);
+                    bool strlen_call_succeeded = false;
+                    auto dlerror_len = remote_call(pid, regs, (uintptr_t) strlen_addr,
+                                                   (uintptr_t) libc_return_addr, args,
+                                                   &strlen_call_succeeded);
+                    if (strlen_call_succeeded && dlerror_len > 0 && dlerror_len < 4096) {
+                        std::string err((size_t) dlerror_len + 1, 0);
+                        read_proc(pid, (uintptr_t) dlerror_str_addr, err.data(), dlerror_len);
+                        LOGW("dlopen error: %s", err.c_str());
+                    }
+                }
+            }
         }
-        args.clear();
-        auto dlerror_str_addr =
-            remote_call(pid, regs, (uintptr_t) dlerror_addr, (uintptr_t) libc_return_addr, args);
-        if (dlerror_str_addr == 0) {
-            return abort_injection("remote call to dlerror returned null");
-        }
-        auto strlen_addr = find_func_addr(local_map, map, "libc.so", "strlen");
-        if (strlen_addr == nullptr) {
-            return abort_injection("could not find address of strlen; cannot measure error string length");
-        }
-        args.clear();
-        args.push_back(dlerror_str_addr);
-        auto dlerror_len =
-            remote_call(pid, regs, (uintptr_t) strlen_addr, (uintptr_t) libc_return_addr, args);
-        if (dlerror_len <= 0) {
-            return abort_injection("dlerror string length is invalid");
-        }
-        std::string err;
-        err.resize(dlerror_len + 1, 0);
-        read_proc(pid, (uintptr_t) dlerror_str_addr, err.data(), dlerror_len);
-        LOGE("dlopen error: %s", err.c_str());
-        set_regs(pid, backup);
-        return false;
-    }
-    LOGI("successfully loaded library via remote dlopen, handle: 0x%" PRIxPTR, remote_handle);
 
-    // Remotely call dlsym(handle, "entry")
-    LOGV("executing remote call to dlsym to find the 'entry' symbol");
-    auto dlsym_addr = find_func_addr(local_map, map, "libdl.so", "dlsym");
-    if (dlsym_addr == nullptr) {
-        return abort_injection("could not find address of dlsym in the target process");
-    }
-    args.clear();
-    auto remote_entry_str = push_string(pid, regs, "entry");
-    args.push_back(remote_handle);
-    args.push_back((long) remote_entry_str);
-    auto injector_entry =
-        remote_call(pid, regs, (uintptr_t) dlsym_addr, (uintptr_t) libc_return_addr, args);
-
-    if (injector_entry == 0) {
-        return abort_injection("dlsym failed to find the 'entry' symbol in the injected library");
-    }
-    LOGI("found injector entry point at address 0x%" PRIxPTR, injector_entry);
-
-    // Find the address range of the injected library to pass to its entry function.
-    map = MapInfo::Scan(std::to_string(pid));
-    void *start_addr = nullptr;
-    size_t block_size = 0;
-    for (const auto &info : map) {
-        if (info.path.find("libzygisk.so") != std::string::npos) {
-            if (start_addr == nullptr) start_addr = (void *) info.start;
-            block_size += (info.end - info.start);
+        uintptr_t rc_base = 0, rc_entry = 0;
+        size_t rc_size = 0;
+        if (!remote_csoloader_load_and_resolve_entry(pid, regs, map, local_map, lib_path,
+                                                      &rc_base, &rc_size, &rc_entry)) {
+            return abort_injection("both remote dlopen and the custom loader failed");
         }
+        start_addr = (void *) rc_base;
+        block_size = rc_size;
+        injector_entry = rc_entry;
+        custom_loaded = true;
+        LOGI("mapped libzygisk via the custom loader fallback at %p (entry 0x%" PRIxPTR ")",
+             start_addr, injector_entry);
     }
-    LOGV("found injected library mapped from %p with total size %zu", start_addr, block_size);
 
     // Remotely call our entry(start_addr, block_size, path) function
     LOGI("calling the injector's entry function to initialize OnyxZygisk");
-    args.clear();
-    args.push_back((uintptr_t) start_addr);
-    args.push_back(block_size);
+    std::vector<long> entry_args;
+    entry_args.push_back((uintptr_t) start_addr);
+    entry_args.push_back(block_size);
     auto remote_tmp_path = push_string(pid, regs, zygiskd::GetTmpPath().c_str());
-    args.push_back((long) remote_tmp_path);
-    remote_call(pid, regs, injector_entry, (uintptr_t) libc_return_addr, args);
+    entry_args.push_back((long) remote_tmp_path);
+    entry_args.push_back(custom_loaded);
+    bool entry_succeeded = false;
+    remote_call(pid, regs, injector_entry, (uintptr_t) libc_return_addr, entry_args,
+                &entry_succeeded);
+    if (!entry_succeeded) {
+        return abort_injection("libzygisk entry function failed before initialization completed");
+    }
 
     // --- Step 5: Restore State ---
     // `backup.REG_IP` was already set back to the original entry address above.

--- a/loader/src/ptracer/remote_csoloader.cpp
+++ b/loader/src/ptracer/remote_csoloader.cpp
@@ -1,0 +1,1021 @@
+// Remote in-process custom loader: maps libzygisk.so into the tracee without
+// the system linker, so the library never enters the linker's solist and is not
+// subject to the namespace allowlist that rejects a path-based dlopen on some
+// KernelSU LKM late-load setups. See remote_csoloader.hpp.
+//
+// Adapted from PerformanC/ReZygisk (GPL-3.0), part of the CSOLoader project;
+// conveyed under AGPL-3.0 per GPL-3.0 §13. See NOTICE.md.
+
+#include "remote_csoloader.hpp"
+
+#include <elf.h>
+#include <fcntl.h>
+#include <link.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cinttypes>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <string_view>
+
+#include "daemon.hpp"  // LP_SELECT
+#include "logging.hpp"
+
+// mmap on LP64 takes a byte offset; the 32-bit ABI uses mmap2 with a page-unit
+// offset. The other syscalls have a single number across ABIs.
+static constexpr long SYS_MMAP = LP_SELECT(__NR_mmap2, __NR_mmap);
+
+#ifndef ALIGN_DOWN
+#define ALIGN_DOWN(x, a) ((x) & ~((a) - 1))
+#endif
+#ifndef ALIGN_UP
+#define ALIGN_UP(x, a) (((x) + ((a) - 1)) & ~((a) - 1))
+#endif
+
+// --- Local file / paging helpers ---------------------------------------------
+
+// Reads exactly `len` bytes from `fd` at absolute offset `off` (local file).
+static bool pread_full(int fd, void *buf, size_t len, off_t off) {
+    auto *p = static_cast<uint8_t *>(buf);
+    size_t done = 0;
+    while (done < len) {
+        ssize_t n = pread(fd, p + done, len - done, off + (off_t) done);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        if (n == 0) return false;  // unexpected EOF
+        done += (size_t) n;
+    }
+    return true;
+}
+
+static uintptr_t page_start(uintptr_t addr, size_t page_size) {
+    return ALIGN_DOWN(addr, page_size);
+}
+
+static uintptr_t page_end(uintptr_t addr, size_t page_size) {
+    return ALIGN_DOWN(addr + page_size - 1, page_size);
+}
+
+static long remote_mmap_offset_arg(off_t file_offset, size_t page_size) {
+#ifdef __LP64__
+    (void) page_size;
+    return (long) file_offset;
+#else
+    return (long) (file_offset / (off_t) page_size);
+#endif
+}
+
+// --- ELF layout / dynamic parsing --------------------------------------------
+
+// Parse the ELF header + program headers and compute the total span of all
+// PT_LOAD segments (page-aligned). Allocates *out_phdr (caller frees).
+static bool compute_load_layout(int fd, size_t page_size, ElfW(Ehdr) * eh, ElfW(Phdr) * *out_phdr,
+                                ElfW(Addr) * out_min_vaddr, size_t *out_map_size) {
+    if (!pread_full(fd, eh, sizeof(*eh), 0)) {
+        LOGE("failed to read ELF header");
+        return false;
+    }
+    if (memcmp(eh->e_ident, ELFMAG, SELFMAG) != 0) {
+        LOGE("invalid ELF magic");
+        return false;
+    }
+
+    size_t phdr_sz = (size_t) eh->e_phnum * sizeof(ElfW(Phdr));
+    auto *phdr = (ElfW(Phdr) *) malloc(phdr_sz);
+    if (!phdr) {
+        LOGE("failed to allocate program headers");
+        return false;
+    }
+    if (!pread_full(fd, phdr, phdr_sz, (off_t) eh->e_phoff)) {
+        LOGE("failed to read program headers");
+        free(phdr);
+        return false;
+    }
+
+    auto lo = (ElfW(Addr)) UINTPTR_MAX;
+    ElfW(Addr) hi = 0;
+    for (int i = 0; i < eh->e_phnum; i++) {
+        if (phdr[i].p_type != PT_LOAD) continue;
+        if (phdr[i].p_vaddr < lo) lo = phdr[i].p_vaddr;
+        ElfW(Addr) end = phdr[i].p_vaddr + phdr[i].p_memsz;
+        if (end > hi) hi = end;
+    }
+    if (hi <= lo) {
+        LOGE("no valid PT_LOAD segments");
+        free(phdr);
+        return false;
+    }
+
+    lo = (ElfW(Addr)) page_start((uintptr_t) lo, page_size);
+    hi = (ElfW(Addr)) page_end((uintptr_t) hi, page_size);
+
+    *out_min_vaddr = lo;
+    *out_map_size = (size_t) (hi - lo);
+    *out_phdr = phdr;
+    return true;
+}
+
+// Map an ELF virtual address to its file offset via the PT_LOAD tables.
+static bool vaddr_to_offset(const ElfW(Phdr) * phdr, int phnum, ElfW(Addr) vaddr, off_t *out_off) {
+    for (int i = 0; i < phnum; i++) {
+        if (phdr[i].p_type != PT_LOAD) continue;
+        ElfW(Addr) seg_start = phdr[i].p_vaddr;
+        ElfW(Addr) seg_end = phdr[i].p_vaddr + phdr[i].p_filesz;
+        if (vaddr < seg_start || vaddr >= seg_end) continue;
+        *out_off = (off_t) phdr[i].p_offset + (off_t) (vaddr - seg_start);
+        return true;
+    }
+    LOGE("failed to map vaddr 0x%" PRIxPTR " to a file offset", (uintptr_t) vaddr);
+    return false;
+}
+
+// Find the full remote path of a mapped module by its soname (base==0 mapping).
+static const char *find_remote_module_path(const std::vector<MapInfo> &remote_map,
+                                           const char *soname) {
+    for (const auto &m : remote_map) {
+        if (m.path.empty() || m.offset != 0) continue;
+        std::string_view p(m.path);
+        auto slash = p.rfind('/');
+        std::string_view filename = (slash == std::string_view::npos) ? p : p.substr(slash + 1);
+        if (filename == soname) return m.path.c_str();
+    }
+    return nullptr;
+}
+
+struct elf_dyn_info {
+    off_t dyn_off;
+    size_t dyn_sz;
+    off_t symtab_off;
+    off_t strtab_off;
+    off_t rel_off;
+    size_t rel_sz;
+    off_t rela_off;
+    size_t rela_sz;
+    off_t jmprel_off;
+    size_t jmprel_sz;
+    int pltrel_type;
+    size_t syment;
+    size_t strsz;
+    size_t nsyms;
+    char *strtab;
+    size_t needed_count;
+    size_t *needed_str_offsets;
+    ElfW(Addr) init_vaddr;
+    ElfW(Addr) init_array_vaddr;
+    size_t init_array_sz;
+};
+
+static void elf_dyn_info_destroy(struct elf_dyn_info *info) {
+    if (!info) return;
+    free(info->strtab);
+    free(info->needed_str_offsets);
+    memset(info, 0, sizeof(*info));
+}
+
+// Parse PT_DYNAMIC and extract the relocation and symbol-table descriptors.
+static bool elf_load_dyn_info(int fd, const ElfW(Ehdr) * eh, const ElfW(Phdr) * phdr,
+                              struct elf_dyn_info *out) {
+    memset(out, 0, sizeof(*out));
+
+    // Everything is declared up front so the goto-cleanup below never bypasses
+    // an initialization (which C++ forbids, unlike C).
+    ElfW(Dyn) *dyn = nullptr;
+    size_t *needed_str_offsets = nullptr;
+    bool success = false;
+
+    ElfW(Addr) symtab_vaddr = 0, strtab_vaddr = 0, gnu_hash_vaddr = 0;
+    ElfW(Addr) rel_vaddr = 0, rela_vaddr = 0, jmprel_vaddr = 0;
+    size_t rel_sz = 0, rela_sz = 0, jmprel_sz = 0, strsz = 0, syment = 0;
+    size_t dyn_count = 0, needed_count = 0, needed_i = 0;
+
+    const ElfW(Phdr) *dyn_phdr = nullptr;
+    for (int i = 0; i < eh->e_phnum; i++) {
+        if (phdr[i].p_type == PT_DYNAMIC) {
+            dyn_phdr = &phdr[i];
+            break;
+        }
+    }
+    if (!dyn_phdr || dyn_phdr->p_filesz == 0) {
+        LOGE("failed to find PT_DYNAMIC");
+        return false;
+    }
+
+    out->dyn_off = (off_t) dyn_phdr->p_offset;
+    out->dyn_sz = (size_t) dyn_phdr->p_filesz;
+    dyn_count = out->dyn_sz / sizeof(ElfW(Dyn));
+
+    dyn = (ElfW(Dyn) *) calloc(dyn_count, sizeof(ElfW(Dyn)));
+    if (!dyn) {
+        LOGE("failed to allocate dynamic entries");
+        return false;
+    }
+    if (!pread_full(fd, dyn, dyn_count * sizeof(ElfW(Dyn)), out->dyn_off)) {
+        LOGE("failed to read dynamic entries");
+        goto cleanup;
+    }
+
+    for (size_t i = 0; i < dyn_count; i++) {
+        if (dyn[i].d_tag == DT_NEEDED) needed_count++;
+        if (dyn[i].d_tag == DT_NULL) break;
+    }
+    if (needed_count) {
+        needed_str_offsets = (size_t *) calloc(needed_count, sizeof(size_t));
+        if (!needed_str_offsets) {
+            LOGE("failed to allocate DT_NEEDED offsets");
+            goto cleanup;
+        }
+    }
+
+    for (size_t i = 0; i < dyn_count; i++) {
+        switch ((uintptr_t) dyn[i].d_tag) {
+        case DT_SYMTAB: symtab_vaddr = (ElfW(Addr)) dyn[i].d_un.d_ptr; break;
+        case DT_STRTAB: strtab_vaddr = (ElfW(Addr)) dyn[i].d_un.d_ptr; break;
+        case DT_STRSZ: strsz = (size_t) dyn[i].d_un.d_val; break;
+        case DT_SYMENT: syment = (size_t) dyn[i].d_un.d_val; break;
+        case DT_REL: rel_vaddr = (ElfW(Addr)) dyn[i].d_un.d_ptr; break;
+        case DT_RELSZ: rel_sz = (size_t) dyn[i].d_un.d_val; break;
+        case DT_RELA: rela_vaddr = (ElfW(Addr)) dyn[i].d_un.d_ptr; break;
+        case DT_RELASZ: rela_sz = (size_t) dyn[i].d_un.d_val; break;
+        case DT_JMPREL: jmprel_vaddr = (ElfW(Addr)) dyn[i].d_un.d_ptr; break;
+        case DT_PLTRELSZ: jmprel_sz = (size_t) dyn[i].d_un.d_val; break;
+        case DT_PLTREL: out->pltrel_type = (int) dyn[i].d_un.d_val; break;
+        case DT_GNU_HASH: gnu_hash_vaddr = (ElfW(Addr)) dyn[i].d_un.d_ptr; break;
+        case DT_INIT: out->init_vaddr = (ElfW(Addr)) dyn[i].d_un.d_ptr; break;
+        case DT_INIT_ARRAY: out->init_array_vaddr = (ElfW(Addr)) dyn[i].d_un.d_ptr; break;
+        case DT_INIT_ARRAYSZ: out->init_array_sz = (size_t) dyn[i].d_un.d_val; break;
+        case DT_NEEDED:
+            if (needed_str_offsets && needed_i < needed_count)
+                needed_str_offsets[needed_i++] = (size_t) dyn[i].d_un.d_val;
+            break;
+        case DT_NULL: i = dyn_count; break;
+        }
+    }
+
+    if (!syment) syment = sizeof(ElfW(Sym));
+    if (!symtab_vaddr || !strtab_vaddr || !strsz) {
+        LOGE("missing DT_SYMTAB/DT_STRTAB/DT_STRSZ");
+        goto cleanup;
+    }
+
+    if (!vaddr_to_offset(phdr, eh->e_phnum, symtab_vaddr, &out->symtab_off) ||
+        !vaddr_to_offset(phdr, eh->e_phnum, strtab_vaddr, &out->strtab_off)) {
+        LOGE("failed vaddr_to_offset for symtab/strtab");
+        goto cleanup;
+    }
+
+    if (rel_vaddr && rel_sz) {
+        if (!vaddr_to_offset(phdr, eh->e_phnum, rel_vaddr, &out->rel_off)) goto cleanup;
+        out->rel_sz = rel_sz;
+    }
+    if (rela_vaddr && rela_sz) {
+        if (!vaddr_to_offset(phdr, eh->e_phnum, rela_vaddr, &out->rela_off)) goto cleanup;
+        out->rela_sz = rela_sz;
+    }
+    if (jmprel_vaddr && jmprel_sz) {
+        if (!vaddr_to_offset(phdr, eh->e_phnum, jmprel_vaddr, &out->jmprel_off)) goto cleanup;
+        out->jmprel_sz = jmprel_sz;
+    }
+
+    out->strtab = (char *) malloc(strsz + 1);
+    if (!out->strtab) {
+        LOGE("failed to allocate string table");
+        goto cleanup;
+    }
+    if (!pread_full(fd, out->strtab, strsz, out->strtab_off)) {
+        LOGE("failed to read string table");
+        free(out->strtab);
+        out->strtab = nullptr;
+        goto cleanup;
+    }
+    out->strtab[strsz] = '\0';
+
+    out->syment = syment;
+    out->strsz = strsz;
+    out->needed_count = needed_count;
+    out->needed_str_offsets = needed_str_offsets;
+    out->nsyms = 0;
+
+    // Derive the symbol count from the GNU hash table so we can iterate dynsym.
+    if (gnu_hash_vaddr) {
+        off_t gnu_hash_off = 0;
+        if (vaddr_to_offset(phdr, eh->e_phnum, gnu_hash_vaddr, &gnu_hash_off)) {
+            uint32_t header[4];
+            if (pread_full(fd, header, sizeof(header), gnu_hash_off)) {
+                uint32_t nbuckets = header[0];
+                uint32_t symoffset = header[1];
+                uint32_t bloom_size = header[2];
+
+                size_t bloom_words = bloom_size * sizeof(ElfW(Addr));
+                off_t buckets_off = gnu_hash_off + 16 + (off_t) bloom_words;
+
+                uint32_t max_bucket = 0;
+                for (uint32_t b = 0; b < nbuckets; b++) {
+                    uint32_t bucket_val;
+                    if (!pread_full(fd, &bucket_val, sizeof(bucket_val),
+                                    buckets_off + (off_t) (b * 4)))
+                        break;
+                    if (bucket_val > max_bucket) max_bucket = bucket_val;
+                }
+
+                if (max_bucket >= symoffset) {
+                    off_t chains_off = buckets_off + (off_t) (nbuckets * 4);
+                    uint32_t chain_idx = max_bucket - symoffset;
+                    uint32_t chain_val;
+                    while (pread_full(fd, &chain_val, sizeof(chain_val),
+                                      chains_off + (off_t) (chain_idx * 4))) {
+                        if (chain_val & 1) {
+                            out->nsyms = max_bucket + 1;
+                            break;
+                        }
+                        max_bucket++;
+                        chain_idx++;
+                    }
+                    if (!out->nsyms) out->nsyms = max_bucket + 1;
+                } else {
+                    out->nsyms = symoffset;
+                }
+            }
+        }
+    }
+
+    success = true;
+
+cleanup:
+    free(dyn);
+    if (!success) free(needed_str_offsets);
+    return success;
+}
+
+// Look up a defined symbol by name in the dynamic symbol table.
+static bool find_dynsym_value(int fd, const struct elf_dyn_info *info, const char *sym_name,
+                              ElfW(Addr) * out_value) {
+    for (size_t i = 0; i < info->nsyms; i++) {
+        ElfW(Sym) sym;
+        if (!pread_full(fd, &sym, sizeof(sym), info->symtab_off + (off_t) (i * info->syment)))
+            break;
+        if (sym.st_name == 0 || sym.st_name >= info->strsz) continue;
+        const char *name = &info->strtab[sym.st_name];
+        if (strcmp(name, sym_name) != 0 || sym.st_shndx == SHN_UNDEF) continue;
+        *out_value = sym.st_value;
+        return true;
+    }
+    LOGE("symbol not found in dynsym: %s", sym_name);
+    return false;
+}
+
+#ifdef __LP64__
+#define ELF_R_TYPE ELF64_R_TYPE
+#define ELF_R_SYM ELF64_R_SYM
+#else
+#define ELF_R_TYPE ELF32_R_TYPE
+#define ELF_R_SYM ELF32_R_SYM
+#endif
+
+// Resolve a symbol referenced by a relocation: local definitions use the load
+// bias; undefined symbols are looked up in the DT_NEEDED libraries (and, for the
+// dl* family, the linker's __dl_* exports).
+static bool resolve_symbol_addr(int fd, const struct elf_dyn_info *info,
+                                const std::vector<MapInfo> &local_map,
+                                const std::vector<MapInfo> &remote_map,
+                                const char *const *needed_paths, uintptr_t load_bias,
+                                size_t sym_idx, uintptr_t *out_addr) {
+    ElfW(Sym) sym;
+    if (!pread_full(fd, &sym, sizeof(sym), info->symtab_off + (off_t) (sym_idx * info->syment)))
+        return false;
+
+    if (sym.st_shndx != SHN_UNDEF) {
+        *out_addr = (uintptr_t) load_bias + (uintptr_t) sym.st_value;
+        return true;
+    }
+
+    if (sym.st_name == 0 || sym.st_name >= info->strsz) return false;
+    const char *name = &info->strtab[sym.st_name];
+    if (!name || !*name) return false;
+
+    // EH-frame registration is optional in CSOLoader and awkward to resolve
+    // remotely; leave it null (matches upstream).
+    if (strcmp(name, "__register_frame") == 0 || strcmp(name, "__deregister_frame") == 0) {
+        LOGW("bypassing resolution of EH frame function: %s", name);
+        *out_addr = 0;
+        return true;
+    }
+
+    for (size_t i = 0; i < info->needed_count; i++) {
+        const char *mod_path = needed_paths ? needed_paths[i] : nullptr;
+        if (!mod_path) continue;
+        void *addr = find_func_addr(local_map, remote_map, mod_path, name);
+        if (addr) {
+            *out_addr = (uintptr_t) addr;
+            return true;
+        }
+    }
+
+    // The dl* family lives in the linker itself as __dl_* exports; some old
+    // devices don't have libdl.so mapped to resolve them the usual way.
+    if (strcmp(name, "dlopen") == 0 || strcmp(name, "dlsym") == 0 ||
+        strcmp(name, "dlerror") == 0 || strcmp(name, "dl_iterate_phdr") == 0 ||
+        strcmp(name, "dlclose") == 0) {
+        const char *linker_dl_symbol = "__dl_dlopen";
+        if (strcmp(name, "dlsym") == 0) linker_dl_symbol = "__dl_dlsym";
+        else if (strcmp(name, "dlerror") == 0) linker_dl_symbol = "__dl_dlerror";
+        else if (strcmp(name, "dl_iterate_phdr") == 0) linker_dl_symbol = "__dl_dl_iterate_phdr";
+        else if (strcmp(name, "dlclose") == 0) linker_dl_symbol = "__dl_dlclose";
+
+        LOGD("resolving %s from the linker as %s", name, linker_dl_symbol);
+        void *addr = find_func_addr(local_map, remote_map,
+                                    "/system/bin/" LP_SELECT("linker", "linker64"), linker_dl_symbol);
+        if (addr) {
+            *out_addr = (uintptr_t) addr;
+            return true;
+        }
+    }
+
+    LOGE("failed to resolve external symbol %s", name);
+    return false;
+}
+
+static bool write_remote_addr(int pid, uintptr_t addr, ElfW(Addr) value) {
+    return write_proc(pid, addr, &value, sizeof(value)) == (ssize_t) sizeof(value);
+}
+
+static bool read_remote_addr(int pid, uintptr_t addr, ElfW(Addr) * out) {
+    return read_proc(pid, addr, out, sizeof(*out)) == (ssize_t) sizeof(*out);
+}
+
+// Apply RELA-format relocations (aarch64 / x86_64, and the generic relative).
+static bool apply_rela_section(int pid, int fd, const struct elf_dyn_info *info,
+                               const std::vector<MapInfo> &local_map,
+                               const std::vector<MapInfo> &remote_map,
+                               const char *const *needed_paths, uintptr_t load_bias, off_t rela_off,
+                               size_t rela_sz) {
+    size_t count = rela_sz / sizeof(ElfW(Rela));
+    for (size_t i = 0; i < count; i++) {
+        ElfW(Rela) r;
+        if (!pread_full(fd, &r, sizeof(r), rela_off + (off_t) (i * sizeof(r)))) return false;
+
+        unsigned type = (unsigned) ELF_R_TYPE(r.r_info);
+        unsigned sym = (unsigned) ELF_R_SYM(r.r_info);
+        uintptr_t target = (uintptr_t) load_bias + (uintptr_t) r.r_offset;
+        ElfW(Addr) value = 0;
+
+#if defined(__aarch64__)
+        if (type == R_AARCH64_RELATIVE) {
+            value = (ElfW(Addr)) load_bias + (ElfW(Addr)) r.r_addend;
+        } else if (type == R_AARCH64_GLOB_DAT || type == R_AARCH64_JUMP_SLOT ||
+                   type == R_AARCH64_ABS64) {
+            uintptr_t sym_addr = 0;
+            if (!resolve_symbol_addr(fd, info, local_map, remote_map, needed_paths, load_bias, sym,
+                                     &sym_addr))
+                return false;
+            value = sym_addr ? (ElfW(Addr)) sym_addr + (ElfW(Addr)) r.r_addend : 0;
+        } else {
+            LOGE("unsupported AArch64 RELA type %u", type);
+            return false;
+        }
+#elif defined(__x86_64__)
+        if (type == R_X86_64_RELATIVE) {
+            value = (ElfW(Addr)) load_bias + (ElfW(Addr)) r.r_addend;
+        } else if (type == R_X86_64_GLOB_DAT || type == R_X86_64_JUMP_SLOT || type == R_X86_64_64) {
+            uintptr_t sym_addr = 0;
+            if (!resolve_symbol_addr(fd, info, local_map, remote_map, needed_paths, load_bias, sym,
+                                     &sym_addr))
+                return false;
+            value = sym_addr ? (ElfW(Addr)) sym_addr + (ElfW(Addr)) r.r_addend : 0;
+        } else {
+            LOGE("unsupported x86_64 RELA type %u", type);
+            return false;
+        }
+#else
+        (void) info;
+        (void) local_map;
+        (void) remote_map;
+        (void) sym;
+        (void) needed_paths;
+        if (type == 0) {
+            value = (ElfW(Addr)) load_bias + (ElfW(Addr)) r.r_addend;
+        } else {
+            LOGE("unsupported RELA type %u", type);
+            return false;
+        }
+#endif
+
+        if (!write_remote_addr(pid, target, value)) return false;
+    }
+    return true;
+}
+
+// Apply REL-format relocations (arm / i386, and the generic relative).
+static bool apply_rel_section(int pid, int fd, const struct elf_dyn_info *info,
+                              const std::vector<MapInfo> &local_map,
+                              const std::vector<MapInfo> &remote_map,
+                              const char *const *needed_paths, uintptr_t load_bias, off_t rel_off,
+                              size_t rel_sz) {
+    size_t count = rel_sz / sizeof(ElfW(Rel));
+    for (size_t i = 0; i < count; i++) {
+        ElfW(Rel) r;
+        if (!pread_full(fd, &r, sizeof(r), rel_off + (off_t) (i * sizeof(r)))) return false;
+
+        unsigned type = (unsigned) ELF_R_TYPE(r.r_info);
+        unsigned sym = (unsigned) ELF_R_SYM(r.r_info);
+        uintptr_t target = (uintptr_t) load_bias + (uintptr_t) r.r_offset;
+        ElfW(Addr) addend = 0;
+        ElfW(Addr) value = 0;
+
+#if defined(__arm__)
+        if (type == R_ARM_RELATIVE) {
+            if (!read_remote_addr(pid, target, &addend)) return false;
+            value = (ElfW(Addr)) load_bias + addend;
+        } else if (type == R_ARM_GLOB_DAT || type == R_ARM_JUMP_SLOT || type == R_ARM_ABS32) {
+            uintptr_t sym_addr = 0;
+            if (!resolve_symbol_addr(fd, info, local_map, remote_map, needed_paths, load_bias, sym,
+                                     &sym_addr))
+                return false;
+            if (sym_addr == 0) {
+                value = 0;
+            } else if (type == R_ARM_ABS32) {
+                if (!read_remote_addr(pid, target, &addend)) return false;
+                value = (ElfW(Addr)) sym_addr + addend;
+            } else {
+                value = (ElfW(Addr)) sym_addr;
+            }
+        } else {
+            LOGE("unsupported ARM REL type %u", type);
+            return false;
+        }
+#elif defined(__i386__)
+        if (type == R_386_RELATIVE) {
+            if (!read_remote_addr(pid, target, &addend)) return false;
+            value = (ElfW(Addr)) load_bias + addend;
+        } else if (type == R_386_GLOB_DAT || type == R_386_JMP_SLOT || type == R_386_32) {
+            uintptr_t sym_addr = 0;
+            if (!resolve_symbol_addr(fd, info, local_map, remote_map, needed_paths, load_bias, sym,
+                                     &sym_addr))
+                return false;
+            if (sym_addr == 0) {
+                value = 0;
+            } else if (type == R_386_32) {
+                if (!read_remote_addr(pid, target, &addend)) return false;
+                value = (ElfW(Addr)) sym_addr + addend;
+            } else {
+                value = (ElfW(Addr)) sym_addr;
+            }
+        } else {
+            LOGE("unsupported i386 REL type %u", type);
+            return false;
+        }
+#else
+        (void) info;
+        (void) local_map;
+        (void) remote_map;
+        (void) sym;
+        (void) needed_paths;
+        (void) addend;
+        (void) target;
+        LOGE("REL relocations are not supported on this architecture");
+        return false;
+#endif
+
+        if (!write_remote_addr(pid, target, value)) return false;
+    }
+    return true;
+}
+
+static bool apply_relocations(int pid, int fd, const struct elf_dyn_info *info,
+                              const std::vector<MapInfo> &local_map,
+                              const std::vector<MapInfo> &remote_map,
+                              const char *const *needed_paths, uintptr_t load_bias) {
+    if (info->rela_sz && info->rela_off) {
+        if (!apply_rela_section(pid, fd, info, local_map, remote_map, needed_paths, load_bias,
+                                info->rela_off, info->rela_sz))
+            return false;
+    }
+    if (info->rel_sz && info->rel_off) {
+        if (!apply_rel_section(pid, fd, info, local_map, remote_map, needed_paths, load_bias,
+                               info->rel_off, info->rel_sz))
+            return false;
+    }
+    // PLT relocations use whichever of RELA/REL the DT_PLTREL tag names.
+    if (info->jmprel_sz && info->jmprel_off) {
+        if (info->pltrel_type == DT_RELA) {
+            if (!apply_rela_section(pid, fd, info, local_map, remote_map, needed_paths, load_bias,
+                                    info->jmprel_off, info->jmprel_sz))
+                return false;
+        } else if (info->pltrel_type == DT_REL) {
+            if (!apply_rel_section(pid, fd, info, local_map, remote_map, needed_paths, load_bias,
+                                   info->jmprel_off, info->jmprel_sz))
+                return false;
+        } else {
+            LOGE("unknown DT_PLTREL type %d", info->pltrel_type);
+            return false;
+        }
+    }
+    return true;
+}
+
+// --- Main entry ---------------------------------------------------------------
+
+bool remote_csoloader_load_and_resolve_entry(int pid, struct user_regs_struct &regs,
+                                             const std::vector<MapInfo> &remote_map,
+                                             const std::vector<MapInfo> &local_map,
+                                             const char *lib_path, uintptr_t *out_base,
+                                             size_t *out_total_size, uintptr_t *out_entry) {
+    struct user_regs_struct regs_saved = regs;
+
+    long page_size_long = sysconf(_SC_PAGESIZE);
+    if (page_size_long <= 0) {
+        LOGE("sysconf(_SC_PAGESIZE) failed");
+        return false;
+    }
+    size_t page_size = (size_t) page_size_long;
+
+    // The ELF file is opened locally to read headers/relocations; segment
+    // contents are mapped into the target via a remote openat of the same path.
+    int fd = open(lib_path, O_RDONLY | O_CLOEXEC);
+    if (fd < 0) {
+        PLOGE("open %s", lib_path);
+        return false;
+    }
+
+    ElfW(Ehdr) eh;
+    ElfW(Phdr) *phdr = nullptr;
+    ElfW(Addr) min_vaddr = 0;
+    size_t map_size = 0;
+    if (!compute_load_layout(fd, page_size, &eh, &phdr, &min_vaddr, &map_size)) {
+        LOGE("failed to parse ELF program headers for %s", lib_path);
+        close(fd);
+        return false;
+    }
+
+    // Raw syscalls (rather than remote libc calls) sidestep IBT/GCS enforcement
+    // that can reject a ptrace-driven indirect call into a libc export.
+    uintptr_t syscall_gadget = find_syscall_gadget(pid, remote_map);
+    if (!syscall_gadget) {
+        LOGE("failed to find a syscall gadget");
+        free(phdr);
+        close(fd);
+        return false;
+    }
+
+    long args[6];
+
+    // Stage the path string on the target's stack for the remote openat.
+    size_t path_len = strlen(lib_path) + 1;
+    uintptr_t remote_path = regs_saved.REG_SP - ALIGN_UP(path_len, (size_t) 16);
+    if (write_proc(pid, remote_path, lib_path, path_len) != (ssize_t) path_len) {
+        LOGE("failed to write library path to the target stack");
+        free(phdr);
+        close(fd);
+        return false;
+    }
+    regs.REG_SP = remote_path;
+
+    args[0] = AT_FDCWD;
+    args[1] = (long) remote_path;
+    args[2] = O_RDONLY | O_CLOEXEC;
+    args[3] = 0;
+    long remote_fd = remote_syscall(pid, regs, syscall_gadget, __NR_openat, args, 4);
+    if (remote_fd < 0) {
+        LOGE("remote openat(%s) failed: %ld", lib_path, remote_fd);
+        free(phdr);
+        close(fd);
+        return false;
+    }
+
+    // Scrub the path from the target stack now that the fd is open.
+    {
+        size_t zlen = ALIGN_UP(path_len, (size_t) 16);
+        void *zeros = calloc(1, zlen);
+        if (zeros) {
+            write_proc(pid, remote_path, zeros, zlen);
+            free(zeros);
+        }
+    }
+
+    // Reserve the whole mapping span. On LP64 request a high (4 GiB+) base so it
+    // stays clear of where the target later grows its own VMAs.
+    uintptr_t min_addr = sizeof(void *) == 8 ? 0x100000000ULL : (uintptr_t) 0;
+    args[0] = (long) min_addr;
+    args[1] = (long) map_size;
+    args[2] = PROT_NONE;
+    args[3] = MAP_PRIVATE | MAP_ANONYMOUS;
+    args[4] = -1;
+    args[5] = 0;
+    uintptr_t remote_base = (uintptr_t) remote_syscall(pid, regs, syscall_gadget, SYS_MMAP, args, 6);
+    if (!remote_base || remote_base == (uintptr_t) MAP_FAILED) {
+        LOGE("remote mmap reserve failed: %p", (void *) remote_base);
+        args[0] = remote_fd;
+        remote_syscall(pid, regs, syscall_gadget, __NR_close, args, 1);
+        free(phdr);
+        close(fd);
+        return false;
+    }
+#ifdef __LP64__
+    if (remote_base < min_addr) {
+        LOGE("remote mmap reserve returned a low base %p (< %p)", (void *) remote_base,
+             (void *) min_addr);
+        args[0] = (long) remote_base;
+        args[1] = (long) map_size;
+        remote_syscall(pid, regs, syscall_gadget, __NR_munmap, args, 2);
+        args[0] = remote_fd;
+        remote_syscall(pid, regs, syscall_gadget, __NR_close, args, 1);
+        free(phdr);
+        close(fd);
+        return false;
+    }
+#endif
+
+    uintptr_t load_bias = remote_base - (uintptr_t) min_vaddr;
+
+    // Segments recorded here get their final protections applied after
+    // relocations (which need them temporarily writable).
+    struct {
+        uintptr_t addr;
+        size_t len;
+        int final_prot;
+    } segs[64];
+    size_t segs_count = 0;
+
+    for (int i = 0; i < eh.e_phnum; i++) {
+        if (phdr[i].p_type != PT_LOAD) continue;
+
+        uintptr_t seg_start = (uintptr_t) phdr[i].p_vaddr + load_bias;
+        uintptr_t seg_page = page_start(seg_start, page_size);
+        uintptr_t seg_end = (uintptr_t) phdr[i].p_vaddr + (uintptr_t) phdr[i].p_memsz + load_bias;
+        uintptr_t seg_page_end = page_end(seg_end, page_size);
+        size_t seg_page_len = (size_t) (seg_page_end - seg_page);
+
+        off_t seg_offset = (off_t) phdr[i].p_offset;
+        off_t file_page_offset = (off_t) page_start((uintptr_t) seg_offset, page_size);
+        uintptr_t file_end = (uintptr_t) phdr[i].p_vaddr + (uintptr_t) phdr[i].p_filesz + load_bias;
+        uintptr_t file_page_end = page_end(file_end, page_size);
+        bool is_writable = (phdr[i].p_flags & PF_W) != 0;
+
+        // Map the file-backed portion R/W first (relocations patch into it).
+        if (phdr[i].p_filesz > 0) {
+            size_t file_map_len = (size_t) (file_page_end - seg_page);
+            args[0] = (long) seg_page;
+            args[1] = (long) file_map_len;
+            args[2] = PROT_READ | PROT_WRITE;
+            args[3] = MAP_FIXED | MAP_PRIVATE;
+            args[4] = remote_fd;
+            args[5] = remote_mmap_offset_arg(file_page_offset, page_size);
+            uintptr_t seg_map =
+                (uintptr_t) remote_syscall(pid, regs, syscall_gadget, SYS_MMAP, args, 6);
+            if (!seg_map || seg_map == (uintptr_t) MAP_FAILED) {
+                LOGE("remote mmap of file-backed segment %d failed", i);
+                args[0] = remote_fd;
+                remote_syscall(pid, regs, syscall_gadget, __NR_close, args, 1);
+                free(phdr);
+                close(fd);
+                return false;
+            }
+
+            // Zero the tail of the last file page for a writable segment (the
+            // .bss bleed within the final page).
+            if (is_writable && file_page_end > file_end) {
+                size_t tail_len = (size_t) (file_page_end - file_end);
+                void *zeros = calloc(1, tail_len);
+                if (!zeros || write_proc(pid, file_end, zeros, tail_len) != (ssize_t) tail_len) {
+                    LOGE("failed to zero the tail of segment %d", i);
+                    free(zeros);
+                    args[0] = remote_fd;
+                    remote_syscall(pid, regs, syscall_gadget, __NR_close, args, 1);
+                    free(phdr);
+                    close(fd);
+                    return false;
+                }
+                free(zeros);
+            }
+        }
+
+        // Map any remaining anonymous (.bss) pages beyond the file contents.
+        if (seg_page_end > file_page_end) {
+            args[0] = (long) file_page_end;
+            args[1] = (long) (seg_page_end - file_page_end);
+            args[2] = PROT_READ | PROT_WRITE;
+            args[3] = MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS;
+            args[4] = -1;
+            args[5] = 0;
+            uintptr_t bss_map =
+                (uintptr_t) remote_syscall(pid, regs, syscall_gadget, SYS_MMAP, args, 6);
+            if (!bss_map || bss_map == (uintptr_t) MAP_FAILED) {
+                LOGE("remote mmap of bss for segment %d failed", i);
+                args[0] = remote_fd;
+                remote_syscall(pid, regs, syscall_gadget, __NR_close, args, 1);
+                free(phdr);
+                close(fd);
+                return false;
+            }
+        }
+
+        int prot = 0;
+        if (phdr[i].p_flags & PF_R) prot |= PROT_READ;
+        if (phdr[i].p_flags & PF_W) prot |= PROT_WRITE;
+        if (phdr[i].p_flags & PF_X) prot |= PROT_EXEC;
+        if (segs_count < (sizeof(segs) / sizeof(segs[0]))) {
+            segs[segs_count].addr = seg_page;
+            segs[segs_count].len = seg_page_len;
+            segs[segs_count].final_prot = prot;
+            segs_count++;
+        }
+    }
+
+    args[0] = remote_fd;
+    remote_syscall(pid, regs, syscall_gadget, __NR_close, args, 1);
+
+    struct elf_dyn_info dinfo;
+    if (!elf_load_dyn_info(fd, &eh, phdr, &dinfo)) {
+        LOGE("failed to load ELF dynamic info");
+        free(phdr);
+        close(fd);
+        return false;
+    }
+
+    const char **needed_paths = nullptr;
+    if (dinfo.needed_count) {
+        needed_paths = (const char **) calloc(dinfo.needed_count, sizeof(char *));
+        if (!needed_paths) {
+            LOGE("failed to allocate needed-paths array");
+            elf_dyn_info_destroy(&dinfo);
+            free(phdr);
+            close(fd);
+            return false;
+        }
+        for (size_t i = 0; i < dinfo.needed_count; i++) {
+            size_t off = dinfo.needed_str_offsets[i];
+            if (off >= dinfo.strsz) continue;
+            needed_paths[i] = find_remote_module_path(remote_map, &dinfo.strtab[off]);
+        }
+    }
+
+    if (!apply_relocations(pid, fd, &dinfo, local_map, remote_map, needed_paths, load_bias)) {
+        LOGE("failed to apply relocations");
+        free((void *) needed_paths);
+        elf_dyn_info_destroy(&dinfo);
+        free(phdr);
+        close(fd);
+        return false;
+    }
+
+    // Now that relocations are written, tighten each segment to its ELF perms.
+    for (size_t i = 0; i < segs_count; i++) {
+        args[0] = (long) segs[i].addr;
+        args[1] = (long) segs[i].len;
+        args[2] = segs[i].final_prot;
+        long mp_ret = remote_syscall(pid, regs, syscall_gadget, __NR_mprotect, args, 3);
+        if (mp_ret < 0) {
+            LOGE("failed to set final protection on segment at %p: %ld", (void *) segs[i].addr,
+                 mp_ret);
+            args[0] = (long) remote_base;
+            args[1] = (long) map_size;
+            remote_syscall(pid, regs, syscall_gadget, __NR_munmap, args, 2);
+            free((void *) needed_paths);
+            elf_dyn_info_destroy(&dinfo);
+            free(phdr);
+            close(fd);
+            return false;
+        }
+    }
+
+    // A system dlopen runs DT_INIT and DT_INIT_ARRAY before returning. Since
+    // this loader deliberately bypasses the system linker, we must reproduce
+    // that step ourselves. Without it, C++ globals in libzygisk (notably the
+    // daemon path std::string) remain zero-initialized but unconstructed and
+    // entry() crashes on its first assignment.
+    uintptr_t constructor_return =
+        (uintptr_t) find_module_return_addr(remote_map, "libc.so");
+    if (!constructor_return) {
+        LOGE("failed to find a safe return trap for libzygisk constructors");
+        args[0] = (long) remote_base;
+        args[1] = (long) map_size;
+        remote_syscall(pid, regs, syscall_gadget, __NR_munmap, args, 2);
+        free((void *) needed_paths);
+        elf_dyn_info_destroy(&dinfo);
+        free(phdr);
+        close(fd);
+        return false;
+    }
+
+    std::vector<long> constructor_args;
+    auto call_constructor = [&](uintptr_t address, const char *kind, size_t index) {
+        bool succeeded = false;
+        remote_call(pid, regs, address, constructor_return, constructor_args, &succeeded);
+        if (!succeeded) {
+            LOGE("%s constructor %zu at %p failed", kind, index, (void *) address);
+        }
+        return succeeded;
+    };
+
+    if (dinfo.init_vaddr &&
+        !call_constructor(load_bias + (uintptr_t) dinfo.init_vaddr, "DT_INIT", 0)) {
+        args[0] = (long) remote_base;
+        args[1] = (long) map_size;
+        remote_syscall(pid, regs, syscall_gadget, __NR_munmap, args, 2);
+        regs = regs_saved;
+        set_regs(pid, regs_saved);
+        free((void *) needed_paths);
+        elf_dyn_info_destroy(&dinfo);
+        free(phdr);
+        close(fd);
+        return false;
+    }
+
+    if (dinfo.init_array_vaddr && dinfo.init_array_sz) {
+        if (dinfo.init_array_sz % sizeof(ElfW(Addr)) != 0) {
+            LOGE("invalid DT_INIT_ARRAYSZ: %zu", dinfo.init_array_sz);
+            args[0] = (long) remote_base;
+            args[1] = (long) map_size;
+            remote_syscall(pid, regs, syscall_gadget, __NR_munmap, args, 2);
+            regs = regs_saved;
+            set_regs(pid, regs_saved);
+            free((void *) needed_paths);
+            elf_dyn_info_destroy(&dinfo);
+            free(phdr);
+            close(fd);
+            return false;
+        }
+
+        uintptr_t init_array = load_bias + (uintptr_t) dinfo.init_array_vaddr;
+        size_t constructor_count = dinfo.init_array_sz / sizeof(ElfW(Addr));
+        for (size_t i = 0; i < constructor_count; i++) {
+            ElfW(Addr) constructor = 0;
+            if (!read_remote_addr(pid, init_array + i * sizeof(constructor), &constructor)) {
+                LOGE("failed to read DT_INIT_ARRAY constructor %zu", i);
+                args[0] = (long) remote_base;
+                args[1] = (long) map_size;
+                remote_syscall(pid, regs, syscall_gadget, __NR_munmap, args, 2);
+                regs = regs_saved;
+                set_regs(pid, regs_saved);
+                free((void *) needed_paths);
+                elf_dyn_info_destroy(&dinfo);
+                free(phdr);
+                close(fd);
+                return false;
+            }
+            if (!constructor || constructor == (ElfW(Addr)) -1) continue;
+            if (!call_constructor((uintptr_t) constructor, "DT_INIT_ARRAY", i)) {
+                args[0] = (long) remote_base;
+                args[1] = (long) map_size;
+                remote_syscall(pid, regs, syscall_gadget, __NR_munmap, args, 2);
+                regs = regs_saved;
+                set_regs(pid, regs_saved);
+                free((void *) needed_paths);
+                elf_dyn_info_destroy(&dinfo);
+                free(phdr);
+                close(fd);
+                return false;
+            }
+        }
+    }
+
+    ElfW(Addr) entry_value = 0;
+    if (!find_dynsym_value(fd, &dinfo, "entry", &entry_value)) {
+        LOGE("failed to resolve `entry` from the ELF dynsym");
+        args[0] = (long) remote_base;
+        args[1] = (long) map_size;
+        remote_syscall(pid, regs, syscall_gadget, __NR_munmap, args, 2);
+        regs = regs_saved;
+        set_regs(pid, regs_saved);
+        free((void *) needed_paths);
+        elf_dyn_info_destroy(&dinfo);
+        free(phdr);
+        close(fd);
+        return false;
+    }
+    uintptr_t remote_entry = (uintptr_t) load_bias + (uintptr_t) entry_value;
+
+    // Constructor calls intentionally stop at a synthetic return trap and
+    // therefore leave the live register set at that trap.  Hand the caller the
+    // exact pre-loader state so its next remote call starts from a clean stack.
+    regs = regs_saved;
+    if (!set_regs(pid, regs_saved)) {
+        LOGE("failed to restore registers after custom loading");
+        args[0] = (long) remote_base;
+        args[1] = (long) map_size;
+        remote_syscall(pid, regs, syscall_gadget, __NR_munmap, args, 2);
+        free((void *) needed_paths);
+        elf_dyn_info_destroy(&dinfo);
+        free(phdr);
+        close(fd);
+        return false;
+    }
+
+    free((void *) needed_paths);
+    elf_dyn_info_destroy(&dinfo);
+    free(phdr);
+    close(fd);
+
+    *out_base = remote_base;
+    *out_total_size = map_size;
+    *out_entry = remote_entry;
+
+    LOGI("remote-mapped %s at %p (size %zu), entry %p", lib_path, (void *) remote_base, map_size,
+         (void *) remote_entry);
+    return true;
+}

--- a/loader/src/ptracer/remote_csoloader.hpp
+++ b/loader/src/ptracer/remote_csoloader.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <sys/ptrace.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "utils.hpp"  // MapInfo, user_regs_struct, remote syscall primitives
+
+// Maps `lib_path` into the tracee `pid` WITHOUT going through the system linker.
+//
+// It opens the file inside the target, reserves an anonymous region, mmaps each
+// PT_LOAD segment, applies relocations and resolves the module's `entry` symbol
+// -- all driven by raw remote syscalls (see remote_syscall/find_syscall_gadget).
+//
+// Because it never calls dlopen()/android_dlopen_ext(), the library never enters
+// the linker's solist and -- the reason this exists -- is not subject to the
+// bionic linker namespace allowlist that rejects a path-based dlopen on some
+// KernelSU LKM late-load configurations ("library ... not found" despite the
+// file being readable). This is the load path that makes injection work there.
+//
+// On success fills *out_base (mapping base), *out_total_size (reserved size) and
+// *out_entry (absolute address of `entry`) and returns true. `regs` is used as
+// scratch for the remote calls and is left restored to the caller's state.
+//
+// Adapted from PerformanC/ReZygisk (GPL-3.0), itself part of the CSOLoader
+// project; conveyed here under AGPL-3.0 per GPL-3.0 §13. See NOTICE.md.
+bool remote_csoloader_load_and_resolve_entry(int pid, struct user_regs_struct &regs,
+                                             const std::vector<MapInfo> &remote_map,
+                                             const std::vector<MapInfo> &local_map,
+                                             const char *lib_path, uintptr_t *out_base,
+                                             size_t *out_total_size, uintptr_t *out_entry);

--- a/loader/src/ptracer/utils.cpp
+++ b/loader/src/ptracer/utils.cpp
@@ -296,10 +296,14 @@ uintptr_t push_string(int pid, struct user_regs_struct &regs, const char *str) {
  * 6.  Waiting for the process to trap (usually via SIGSEGV at our fake return address).
  * 7.  Reading the function's return value from the appropriate register.
  *
+ * @param call_succeeded Optional unambiguous success flag. This is required for
+ *        void functions, whose valid return value is indistinguishable from the
+ *        historical `0 on failure` return convention.
  * @return The return value of the remote function, or 0 on failure.
  */
 uintptr_t remote_call(int pid, struct user_regs_struct &regs, uintptr_t func_addr,
-                      uintptr_t return_addr, std::vector<long> &args) {
+                      uintptr_t return_addr, std::vector<long> &args, bool *call_succeeded) {
+    if (call_succeeded) *call_succeeded = false;
     align_stack(regs);
     LOGV("calling remote function 0x%" PRIxPTR " with %zu args, return to 0x%" PRIxPTR, func_addr,
          args.size(), return_addr);
@@ -416,6 +420,7 @@ uintptr_t remote_call(int pid, struct user_regs_struct &regs, uintptr_t func_add
     // We expect the tracee to stop at our fake return address.
     if (WIFSTOPPED(status) && static_cast<uintptr_t>(regs.REG_IP) == return_addr) {
         LOGV("remote call returned, result: 0x%" PRIXPTR, (uintptr_t) regs.REG_RET);
+        if (call_succeeded) *call_succeeded = true;
         return regs.REG_RET;
     } else {
         LOGE("process stopped unexpectedly after remote call: %s at ip=0x%" PRIXPTR
@@ -600,4 +605,179 @@ std::string get_program(int pid) {
     }
     buf[sz] = 0;
     return buf;
+}
+
+// --- Raw remote syscall primitive ---------------------------------------------
+
+uintptr_t find_syscall_gadget(int pid, const std::vector<MapInfo> &remote_info) {
+    // The encodings below are the fixed-width syscall-entry instructions per ABI.
+#if defined(__aarch64__)
+    const uint32_t svc_insn = 0xD4000001;  // svc #0
+    const size_t insn_size = sizeof(svc_insn);
+#elif defined(__arm__)
+    const uint16_t thumb_svc_insn = 0xDF00;    // svc 0 (Thumb)
+    const uint32_t arm_svc_insn = 0xEF000000;  // svc 0 (ARM)
+#elif defined(__x86_64__)
+    const uint16_t svc_insn = 0x050F;  // syscall
+    const size_t insn_size = sizeof(svc_insn);
+#elif defined(__i386__)
+    const uint16_t svc_insn = 0x80CD;  // int 0x80
+    const size_t insn_size = sizeof(svc_insn);
+#endif
+
+    // Pass 0 searches the vDSO (always present, tiny, and a natural home for a
+    // syscall instruction); pass 1 falls back to any other executable region.
+    for (int pass = 0; pass < 2; pass++) {
+        bool vdso_only = (pass == 0);
+        for (const auto &m : remote_info) {
+            bool is_vdso = m.path.find("[vdso]") != std::string::npos;
+            if ((m.perms & PROT_EXEC) == 0 || is_vdso != vdso_only) continue;
+
+            size_t region_size = m.end - m.start;
+            size_t cap = vdso_only ? 0x10000 : 0x100000;  // bound the copy/scan
+            if (region_size > cap) region_size = cap;
+
+            std::vector<uint8_t> buf(region_size);
+            if (read_proc(pid, m.start, buf.data(), region_size) != (ssize_t) region_size) {
+                continue;
+            }
+
+#if defined(__arm__)
+            // A 32-bit binary may be ARM or Thumb; scan for both encodings. The
+            // returned Thumb address has its low bit set so callers land in Thumb.
+            for (size_t j = 0; j + sizeof(arm_svc_insn) <= region_size; j += sizeof(uint32_t)) {
+                if (memcmp(buf.data() + j, &arm_svc_insn, sizeof(arm_svc_insn)) == 0) {
+                    LOGV("found ARM syscall gadget at 0x%" PRIxPTR, m.start + j);
+                    return m.start + j;
+                }
+            }
+            for (size_t j = 0; j + sizeof(thumb_svc_insn) <= region_size; j += sizeof(uint16_t)) {
+                if (memcmp(buf.data() + j, &thumb_svc_insn, sizeof(thumb_svc_insn)) == 0) {
+                    LOGV("found Thumb syscall gadget at 0x%" PRIxPTR, m.start + j);
+                    return m.start + j + 1;
+                }
+            }
+#else
+            for (size_t j = 0; j + insn_size <= region_size; j += insn_size) {
+                if (memcmp(buf.data() + j, &svc_insn, insn_size) == 0) {
+                    LOGV("found syscall gadget at 0x%" PRIxPTR, m.start + j);
+                    return m.start + j;
+                }
+            }
+#endif
+        }
+    }
+
+    LOGE("failed to find a syscall gadget in the remote process");
+    return 0;
+}
+
+bool wait_for_ptrace_syscall_stop(int pid, int *status) {
+    while (true) {
+        if (waitpid(pid, status, __WALL) == -1) {
+            if (errno == EINTR) continue;
+            PLOGE("waitpid(%d) awaiting syscall-stop", pid);
+            return false;
+        }
+        if (WIFEXITED(*status) || WIFSIGNALED(*status)) {
+            LOGE("process %d died awaiting syscall-stop: %s", pid, parse_status(*status).c_str());
+            return false;
+        }
+        if (WIFSTOPPED(*status)) return true;
+        // Not a stop we care about (shouldn't normally happen under __WALL); loop.
+    }
+}
+
+long remote_syscall(int pid, struct user_regs_struct &regs, uintptr_t syscall_gadget, long sysnr,
+                    long *args, size_t args_count) {
+    LOGV("remote syscall %ld with %zu args via gadget 0x%" PRIxPTR, sysnr, args_count,
+         syscall_gadget);
+
+    struct user_regs_struct saved{};
+    if (!get_regs(pid, saved)) {
+        LOGE("remote_syscall: failed to save registers");
+        return -1;
+    }
+
+    // Restores the tracee to its pre-syscall state; every exit path runs it.
+    auto restore = [&]() {
+        regs = saved;
+        if (!set_regs(pid, regs)) LOGE("remote_syscall: failed to restore registers");
+    };
+
+#if defined(__aarch64__)
+    regs.regs[8] = sysnr;  // x8 = syscall number
+    for (size_t i = 0; i < 6; i++) regs.regs[i] = 0;
+    for (size_t i = 0; i < args_count && i < 6; i++) regs.regs[i] = args[i];
+    regs.REG_IP = syscall_gadget;
+    // Clear PSTATE.BTYPE so stepping into the vDSO svc is not rejected as an
+    // illegal branch target on BTI-enabled hardware.
+    regs.pstate &= ~(3ULL << 10);
+#elif defined(__arm__)
+    regs.uregs[7] = sysnr;  // r7 = syscall number
+    for (size_t i = 0; i < 6; i++) regs.uregs[i] = 0;
+    for (size_t i = 0; i < args_count && i < 6; i++) regs.uregs[i] = args[i];
+    constexpr unsigned long CPSR_T_MASK = 1lu << 5;
+    if (syscall_gadget & 1) {
+        regs.REG_IP = syscall_gadget & ~1u;
+        regs.uregs[16] |= CPSR_T_MASK;  // enter Thumb
+    } else {
+        regs.REG_IP = syscall_gadget;
+        regs.uregs[16] &= ~CPSR_T_MASK;  // enter ARM
+    }
+#elif defined(__x86_64__)
+    regs.REG_SYSNR = sysnr;
+    regs.rax = sysnr;
+    regs.rdi = regs.rsi = regs.rdx = regs.r10 = regs.r8 = regs.r9 = 0;
+    if (args_count >= 1) regs.rdi = args[0];
+    if (args_count >= 2) regs.rsi = args[1];
+    if (args_count >= 3) regs.rdx = args[2];
+    if (args_count >= 4) regs.r10 = args[3];
+    if (args_count >= 5) regs.r8 = args[4];
+    if (args_count >= 6) regs.r9 = args[5];
+    regs.REG_IP = syscall_gadget;
+#elif defined(__i386__)
+    regs.REG_SYSNR = sysnr;
+    regs.eax = sysnr;
+    regs.ebx = regs.ecx = regs.edx = regs.esi = regs.edi = regs.ebp = 0;
+    if (args_count >= 1) regs.ebx = args[0];
+    if (args_count >= 2) regs.ecx = args[1];
+    if (args_count >= 3) regs.edx = args[2];
+    if (args_count >= 4) regs.esi = args[3];
+    if (args_count >= 5) regs.edi = args[4];
+    if (args_count >= 6) regs.ebp = args[5];
+    regs.REG_IP = syscall_gadget;
+#endif
+
+    if (!set_regs(pid, regs)) {
+        LOGE("remote_syscall: failed to set registers");
+        restore();
+        return -1;
+    }
+
+    // Step through the syscall: the first PTRACE_SYSCALL stops at syscall-entry,
+    // the second at syscall-exit, at which point REG_RET holds the result.
+    for (int i = 0; i < 2; i++) {
+        if (ptrace(PTRACE_SYSCALL, pid, 0, 0) == -1) {
+            PLOGE("remote_syscall: PTRACE_SYSCALL");
+            restore();
+            return -1;
+        }
+        int status;
+        if (!wait_for_ptrace_syscall_stop(pid, &status)) {
+            restore();
+            return -1;
+        }
+    }
+
+    if (!get_regs(pid, regs)) {
+        LOGE("remote_syscall: failed to read result registers");
+        restore();
+        return -1;
+    }
+
+    long ret = (long) regs.REG_RET;
+    LOGV("remote syscall %ld returned %ld", sysnr, ret);
+    restore();
+    return ret;
 }

--- a/loader/src/ptracer/utils.hpp
+++ b/loader/src/ptracer/utils.hpp
@@ -78,7 +78,32 @@ void align_stack(struct user_regs_struct &regs, long preserve = 0);
 uintptr_t push_string(int pid, struct user_regs_struct &regs, const char *str);
 
 uintptr_t remote_call(int pid, struct user_regs_struct &regs, uintptr_t func_addr,
-                      uintptr_t return_addr, std::vector<long> &args);
+                      uintptr_t return_addr, std::vector<long> &args,
+                      bool *call_succeeded = nullptr);
+
+// --- Raw remote syscall primitive (used by the remote custom loader) ---
+//
+// Unlike remote_call(), which invokes a resolved libc *function*, these drive
+// raw syscalls in the tracee via a syscall-instruction gadget. This deliberately
+// avoids calling through libc so it keeps working on devices where IBT/GCS
+// (Indirect Branch Tracking / Guarded Control Stack) enforcement rejects a
+// ptrace-driven indirect call into a libc export.
+
+// Scans the tracee's executable maps (vDSO first, then other exec regions) for a
+// syscall instruction usable as a gadget for remote_syscall(). Returns 0 if none.
+uintptr_t find_syscall_gadget(int pid, const std::vector<MapInfo> &remote_info);
+
+// Waits for the tracee to reach a ptrace syscall-stop. Returns false (rather than
+// exiting, as wait_for_trace() does) if the process died instead of stopping, so
+// a failed remote_syscall can unwind to a fallback path.
+bool wait_for_ptrace_syscall_stop(int pid, int *status);
+
+// Executes a single raw syscall in the tracee through `syscall_gadget`, stepping
+// it with two PTRACE_SYSCALL stops (entry + exit). The tracee's registers are
+// saved before and restored after, so `regs` is left as it was on entry. Returns
+// the syscall's return value, or -1 on a ptrace failure.
+long remote_syscall(int pid, struct user_regs_struct &regs, uintptr_t syscall_gadget, long sysnr,
+                    long *args, size_t args_count);
 
 int fork_dont_care();
 

--- a/loader/src/ptracer/zygote_abi.cpp
+++ b/loader/src/ptracer/zygote_abi.cpp
@@ -18,7 +18,18 @@ ZygoteAbiManager::ZygoteAbiManager(AppMonitor& monitor, bool is_64bit)
 
 const Status& ZygoteAbiManager::get_status() const { return status_; }
 
-void ZygoteAbiManager::notify_injected() { status_.zygote_injected = true; }
+void ZygoteAbiManager::notify_injected() {
+    status_.zygote_injected = true;
+    // A successful injection is proof that the *previous* zygote generation
+    // was healthy. Reset the crash-loop counter so a later, genuinely faulty
+    // zygote starts counting from 1 instead of inheriting the accumulated
+    // count from normal fork activity (app crashes, system_server restarts,
+    // hot-plug restarts, etc.) — which previously pushed the count past the
+    // threshold and made `is_in_crash_loop` stop monitoring a perfectly
+    // healthy device.
+    counter.count = 0;
+    counter.last_start_time = {.tv_sec = 0, .tv_nsec = 0};
+}
 
 void ZygoteAbiManager::set_daemon_info(std::string_view info) { status_.daemon_info = info; }
 
@@ -30,18 +41,49 @@ void ZygoteAbiManager::set_daemon_crashed(std::string_view error) {
 bool ZygoteAbiManager::is_in_crash_loop() {
     struct timespec now{};
     clock_gettime(CLOCK_MONOTONIC, &now);
-    if (now.tv_sec - counter.last_start_time.tv_sec < ZygoteAbiManager::CRASH_LOOP_WINDOW_SECONDS) {
-        counter.count++;
-    } else {
-        counter.count = 1;
+
+    // Only count when the *previous* zygote generation had been injected
+    // but the new one is starting anyway — i.e. the previous zygote died.
+    // init normally only re-forks app_process after a zygote crash or a
+    // deliberate system_server restart (hot-plug). The injection-success
+    // flag is the precise signal: if it was set, the prior zygote reached
+    // a running state, so this new fork is either a crash restart or an
+    // intentional restart. If it was *not* set, the prior attempt did not
+    // even complete injection, and we already counted that failure on the
+    // previous call — do not double-count the same non-start here.
+    bool previous_was_running = status_.zygote_injected;
+    // ensure_daemon_created() below clears zygote_injected for the new
+    // generation; capture the value before that happens.
+    bool count_this_time = previous_was_running;
+
+    if (count_this_time) {
+        if (now.tv_sec - counter.last_start_time.tv_sec <
+            ZygoteAbiManager::CRASH_LOOP_WINDOW_SECONDS) {
+            counter.count++;
+        } else {
+            counter.count = 1;
+        }
+        counter.last_start_time = now;
     }
-    counter.last_start_time = now;
-    return counter.count >= ZygoteAbiManager::CRASH_LOOP_RETRY_COUNT;
+
+    if (counter.count >= ZygoteAbiManager::CRASH_LOOP_RETRY_COUNT) {
+        LOGE("detected zygote crash loop: %d restarts within %d seconds",
+             counter.count, ZygoteAbiManager::CRASH_LOOP_WINDOW_SECONDS);
+        return true;
+    }
+    return false;
 }
 
 bool ZygoteAbiManager::ensure_daemon_created() {
-    status_.zygote_injected = false;
+    // Only clear the injection flag when starting a brand-new zygote
+    // generation (i.e. first time, or after the daemon died and is being
+    // re-created). Clearing it unconditionally on every call previously
+    // destroyed the `is_in_crash_loop` signal: a successful injection set
+    // the flag, then the next `check_and_prepare_injection` call cleared
+    // it before `is_in_crash_loop` could see it, so the crash counter
+    // never incremented even during a real crash loop.
     if (status_.daemon_pid == -1) {
+        status_.zygote_injected = false;
         auto pid = fork();
         if (pid < 0) {
             PLOGE("create daemon (abi=%s)", abi_name_);
@@ -84,6 +126,9 @@ bool ZygoteAbiManager::handle_daemon_exit_if_match(int pid, int process_status) 
         auto status_str = parse_status(process_status);
         LOGW("ZygoteAbiManager: daemon%s (pid %d) exited: %s", abi_name_, pid, status_str.c_str());
         status_.daemon_running = false;
+        // Reset daemon_pid so a future ensure_daemon_created() can fork a
+        // replacement instead of treating the dead PID as still alive.
+        status_.daemon_pid = -1;
         if (status_.daemon_error_info.empty()) {
             status_.daemon_error_info = status_str;
         }

--- a/module/build.gradle.kts
+++ b/module/build.gradle.kts
@@ -114,7 +114,7 @@ androidComponents.onVariants { variant ->
             expand(
                 "moduleId" to moduleId,
                 "moduleName" to moduleName,
-                // Keep the version line clean — build metadata stays in the
+                // Keep the version line clean; build metadata stays in the
                 // zip file name only (OnyxZygisk-v1.0.5-329-<hash>-release.zip).
                 "versionName" to verName,
                 "versionCode" to verCode
@@ -144,7 +144,7 @@ androidComponents.onVariants { variant ->
         // The WebUI ships as static files in the module's `webroot/` directory
         // (KernelSU webroot convention): root manager apps load the page
         // directly from there, no daemon involvement. The files come from the
-        // Vite build output (zygiskd/webui/dist) — see the `webuiBuild` task
+        // Vite build output (zygiskd/webui/dist); see the `webuiBuild` task
         // above. `customize.sh` extracts this directory on install
         // (SKIPUNZIP=1 mode).
         into("webroot") {

--- a/module/src/service.sh
+++ b/module/src/service.sh
@@ -13,6 +13,19 @@ if [ "$ZYGISK_ENABLED" ]; then
   exit 0
 fi
 
+# ── Boot-loop fail-safe: health witness ───────────────────────────────────────
+# zygisk-init.sh increments a counter on every boot; reaching this point plus
+# a grace window proves the boot was healthy, so the counter resets. A boot
+# loop kills the device before the sleep ends, the counter survives, and the
+# injection kill switch eventually latches (see zygisk-init.sh).
+(
+  sleep 120
+  rm -f "@WORK_DIRECTORY@/boot_fail_count"
+  if [ -f "@WORK_DIRECTORY@/injection_disabled" ]; then
+    log -p w -t "zygisk-sh" "Boot-loop fail-safe is latched; injection stays OFF until @WORK_DIRECTORY@/injection_disabled is removed"
+  fi
+) &
+
 cd "$MODDIR"
 
 if [ "$(which magisk)" ]; then

--- a/module/src/zygisk-init.sh
+++ b/module/src/zygisk-init.sh
@@ -18,8 +18,33 @@ TMP_PATH=@WORK_DIRECTORY@
 # Runtime sockets share this directory with persistent user preferences such
 # as hot-plug flags and mount mode. Preserve the directory across reboots and
 # remove only stale IPC endpoints from the previous session.
+#
+# hotplug_restart_guard is deliberately NOT deleted here: it is the hot-plug
+# circuit breaker's crash evidence. If the previous session ended while a
+# restart was armed/observed, the daemon unplugs the named module at startup
+# (see resolve_stale_restart_guard). Deleting the file here would destroy
+# that evidence and let a system_server-crashing module loop every boot.
 create_sys_perm "$TMP_PATH"
-rm -f "$TMP_PATH"/*.sock "$TMP_PATH/init_monitor"
+rm -f "$TMP_PATH"/*.sock "$TMP_PATH/init_monitor" \
+  "$TMP_PATH"/hotplug_activated/*.applying
+
+# ── Boot-loop fail-safe ───────────────────────────────────────────────────────
+# Count consecutive boots that never proved healthy. service.sh clears the
+# counter once the system has been up for a while; reaching the threshold
+# means our injection itself is implicated in a boot loop, so latch the kill
+# switch and let the monitor skip all ptrace/injection for the coming boots
+# until the user clears the flag.
+FAIL_COUNT_FILE="$TMP_PATH/boot_fail_count"
+FAILSAFE_FLAG="$TMP_PATH/injection_disabled"
+fail_count=0
+[ -f "$FAIL_COUNT_FILE" ] && fail_count=$(cat "$FAIL_COUNT_FILE" 2>/dev/null)
+case "$fail_count" in ''|*[!0-9]*) fail_count=0 ;; esac
+fail_count=$((fail_count + 1))
+echo "$fail_count" > "$FAIL_COUNT_FILE"
+if [ "$fail_count" -ge 3 ] && [ ! -f "$FAILSAFE_FLAG" ]; then
+  touch "$FAILSAFE_FLAG"
+  log -p e -t "zygisk-sh" "Boot-loop fail-safe: $fail_count consecutive unhealthy boots; injection latched OFF until $FAILSAFE_FLAG is removed"
+fi
 
 # ── Runtime libraries ─────────────────────────────────────────────────────────
 if [ -f "$MODDIR/lib64/libzygisk.so" ]; then

--- a/zygiskd/src/main.rs
+++ b/zygiskd/src/main.rs
@@ -76,8 +76,8 @@
 mod companion;
 mod constants;
 mod dl;
-mod mount;
 mod r#fn;
+mod mount;
 mod root_impl;
 mod supercall;
 mod utils;
@@ -116,6 +116,26 @@ fn start() {
         Some("root") => {
             root_impl::setup();
             println!("Detected root implementation: {:?}", root_impl::get());
+        }
+        Some("hotplug") => {
+            let Some(name) = args.get(2) else {
+                eprintln!("zygiskd: usage: hotplug <module-id> --workdir <path>");
+                std::process::exit(2);
+            };
+            let workdir = args
+                .iter()
+                .position(|arg| arg == "--workdir")
+                .and_then(|i| args.get(i + 1))
+                .map(String::as_str);
+            let result = mount::switch_mount_namespace(1).and_then(|_| {
+                root_impl::setup();
+                zygiskd::apply_hotplug(workdir, name)
+            });
+            if let Err(e) = result {
+                error!("Hot-plug apply failed: {:#}", e);
+                eprintln!("zygiskd: hot-plug failed: {e:#}");
+                std::process::exit(1);
+            }
         }
         _ => {
             // Default mode: the main daemon. It accepts an optional `--workdir <path>`

--- a/zygiskd/src/utils.rs
+++ b/zygiskd/src/utils.rs
@@ -112,6 +112,28 @@ pub fn get_property(name: &str) -> Result<String> {
     }
 }
 
+/// Sets an Android system property value.
+pub fn set_property(name: &str, value: &str) -> Result<()> {
+    #[cfg(target_os = "android")]
+    {
+        let name_c = CString::new(name)?;
+        let value_c = CString::new(value)?;
+        // Returns 0 on success, -1 on failure.
+        let ret = unsafe { __system_property_set(name_c.as_ptr(), value_c.as_ptr()) };
+        if ret == 0 {
+            Ok(())
+        } else {
+            anyhow::bail!("__system_property_set({name}) returned {ret}")
+        }
+    }
+    // Non-Android builds (host unit tests) have no property service.
+    #[cfg(not(target_os = "android"))]
+    {
+        let _ = (name, value);
+        Ok(())
+    }
+}
+
 // --- Unix Socket and IPC Extensions ---
 
 /// An extension trait for `UnixStream` to simplify reading and writing common data types.
@@ -220,5 +242,5 @@ pub fn is_socket_alive(stream: &UnixStream) -> bool {
 // --- FFI for Android System APIs ---
 unsafe extern "C" {
     fn __system_property_get(name: *const c_char, value: *mut c_char) -> u32;
-    // Other __system_property functions could be declared here if needed.
+    fn __system_property_set(name: *const c_char, value: *const c_char) -> i32;
 }

--- a/zygiskd/src/zygiskd.rs
+++ b/zygiskd/src/zygiskd.rs
@@ -10,8 +10,8 @@
 //!   and managing companion processes.
 
 use crate::constants::{DaemonSocketAction, ProcessFlags, ZKSU_VERSION};
-use crate::mount::{MountNamespace, MountNamespaceManager};
 use crate::r#fn;
+use crate::mount::{MountNamespace, MountNamespaceManager};
 use crate::utils::{self, UnixStreamExt};
 use crate::{constants, lp_select, root_impl};
 use anyhow::{Context as AnyhowContext, Result, bail};
@@ -19,19 +19,20 @@ use log::{debug, error, info, trace, warn};
 use passfd::FdPassingExt;
 use rustix::io::{FdFlags, fcntl_setfd};
 use std::fs;
-use std::io::Error;
+use std::io::{Error, ErrorKind};
 use std::os::fd::AsRawFd;
 use std::os::fd::{AsFd, OwnedFd, RawFd};
 use std::os::unix::process::CommandExt;
 use std::{
     os::unix::net::{UnixListener, UnixStream},
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Stdio},
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, Mutex, OnceLock,
+        atomic::{AtomicBool, Ordering},
     },
     thread,
+    time::Duration,
 };
 
 /// A classic Zygisk module, as scanned fresh from `PATH_MODULES_DIR`.
@@ -73,6 +74,9 @@ pub fn main(tmp_path: Option<&str>) -> Result<()> {
     info!("Welcome to OnyxZygisk ({}) !", ZKSU_VERSION);
 
     initialize_globals(tmp_path)?;
+    // Cross-boot circuit breaker: resolve a hot-plug restart guard left over
+    // from a crashed session BEFORE any module library is served.
+    resolve_stale_restart_guard();
     // One-time snapshot for the startup log only; every actual request re-scans
     // fresh (see `load_modules`), so this does not need to stay in sync with
     // modules installed/removed later. activate=false: must not run/rename a
@@ -144,6 +148,7 @@ fn handle_connection(mut stream: UnixStream, context: Arc<AppContext>) -> Result
         DaemonSocketAction::SystemServerStarted => {
             let value = constants::SYSTEM_SERVER_STARTED;
             utils::unix_datagram_sendto(CONTROLLER_SOCKET.get().unwrap(), &value.to_le_bytes())?;
+            handle_hotplug_restart_guard();
             // FN `boot` (service.sh) scripts run at late-start, after
             // system_server is up — the same point Magisk runs service.sh.
             r#fn::run_fn_scripts(TMP_PATH.get().unwrap(), "boot");
@@ -250,6 +255,13 @@ fn send_startup_info(modules: &[Module]) -> Result<()> {
         .context("Failed to send startup info to controller")
 }
 
+fn refresh_controller_info() {
+    match load_modules(false).and_then(|modules| send_startup_info(&modules)) {
+        Ok(()) => info!("Hot-plug: refreshed runtime module status"),
+        Err(e) => warn!("Hot-plug: failed to refresh runtime module status: {}", e),
+    }
+}
+
 /// Detects the device architecture.
 fn get_arch() -> Result<&'static str> {
     let system_arch = utils::get_property("ro.product.cpu.abi")?;
@@ -282,7 +294,9 @@ fn staged_update_ready(name: &str) -> bool {
     let dir = Path::new(constants::PATH_MODULES_UPDATE_DIR).join(name);
     dir.join("module.prop").exists()
         && (dir.join("zygisk/arm64-v8a.so").exists()
-            || dir.join("zygisk/armeabi-v7a.so").exists())
+            || dir.join("zygisk/armeabi-v7a.so").exists()
+            || dir.join("zygisk/x86_64.so").exists()
+            || dir.join("zygisk/x86.so").exists())
 }
 
 /// Whether the user explicitly opted `name` into using its staged update
@@ -295,7 +309,10 @@ fn staged_update_ready(name: &str) -> bool {
 /// root solution's own official boot-time commit. Requiring this opt-in too
 /// turns that automatic behavior into an explicit, per-module confirmation.
 fn hotplug_opted_in(name: &str) -> bool {
-    Path::new(TMP_PATH.get().unwrap()).join("hotplug").join(name).exists()
+    Path::new(TMP_PATH.get().unwrap())
+        .join("hotplug")
+        .join(name)
+        .exists()
 }
 
 /// Master switch for the whole hot-plug feature (`WORKDIR/hotplug_off`
@@ -303,7 +320,148 @@ fn hotplug_opted_in(name: &str) -> bool {
 /// only take effect through the root solution's own boot-time swap — i.e. a
 /// reboot. Absent by default, so hot-plug is on out of the box.
 fn hotplug_master_enabled() -> bool {
-    !Path::new(TMP_PATH.get().unwrap()).join("hotplug_off").exists()
+    !Path::new(TMP_PATH.get().unwrap())
+        .join("hotplug_off")
+        .exists()
+}
+
+fn valid_module_id(name: &str) -> bool {
+    !name.is_empty()
+        && name != "."
+        && name != ".."
+        && name
+            .bytes()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, b'.' | b'_' | b'-'))
+}
+
+/// Cross-process lock: both ABI daemons and the WebUI CLI can activate a
+/// module concurrently, so a process-local Mutex cannot protect the swap.
+struct HotplugFileLock(fs::File);
+
+impl Drop for HotplugFileLock {
+    fn drop(&mut self) {
+        unsafe {
+            libc::flock(self.0.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+}
+
+fn acquire_hotplug_lock() -> Result<HotplugFileLock> {
+    let work = Path::new(TMP_PATH.get().unwrap());
+    fs::create_dir_all(work)?;
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(work.join("hotplug.lock"))?;
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+        return Err(Error::last_os_error()).context("failed to lock hot-plug transaction");
+    }
+    Ok(HotplugFileLock(file))
+}
+
+fn activation_markers() -> PathBuf {
+    Path::new(TMP_PATH.get().unwrap()).join("hotplug_activated")
+}
+
+fn activation_marker(name: &str, suffix: &str) -> PathBuf {
+    activation_markers().join(format!("{name}.{suffix}"))
+}
+
+fn write_activation_marker(name: &str, suffix: &str) {
+    let marker = activation_marker(name, suffix);
+    if let Some(parent) = marker.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = fs::write(marker, b"1");
+}
+
+fn clear_activation_markers(name: &str) {
+    for suffix in ["post_fs_data", "service", "restarted", "applying", "state"] {
+        let _ = fs::remove_file(activation_marker(name, suffix));
+    }
+}
+
+/// Move a complete staged module into the real active directory with rollback.
+fn swap_staged_module(name: &str, module_dir: &Path) -> Result<PathBuf> {
+    if !valid_module_id(name) {
+        bail!("invalid hot-plug module id: {name}");
+    }
+    let expected = Path::new(constants::PATH_MODULES_UPDATE_DIR).join(name);
+    if module_dir != expected || !staged_update_ready(name) {
+        bail!("staged module {name} is missing or incomplete");
+    }
+
+    let _lock = acquire_hotplug_lock()?;
+    if !staged_update_ready(name) {
+        bail!("staged module {name} was already activated");
+    }
+    if !fs::symlink_metadata(module_dir)?.file_type().is_dir() {
+        bail!(
+            "staged module path is not a real directory: {}",
+            module_dir.display()
+        );
+    }
+
+    let active_dir = Path::new(constants::PATH_MODULES_DIR).join(name);
+    let backup_dir =
+        Path::new(constants::PATH_MODULES_UPDATE_DIR).join(format!(".onyx-hotplug-backup-{name}"));
+    if backup_dir.exists() {
+        fs::remove_dir_all(&backup_dir).with_context(|| {
+            format!(
+                "failed to remove stale hot-plug backup {}",
+                backup_dir.display()
+            )
+        })?;
+    }
+
+    let had_active = active_dir.exists();
+    if had_active {
+        if !fs::symlink_metadata(&active_dir)?.file_type().is_dir() {
+            bail!(
+                "active module path is not a real directory: {}",
+                active_dir.display()
+            );
+        }
+        if active_dir.join("disable").exists() && !module_dir.join("disable").exists() {
+            fs::write(module_dir.join("disable"), b"")?;
+        }
+        fs::rename(&active_dir, &backup_dir).with_context(|| {
+            format!("failed to preserve active module {}", active_dir.display())
+        })?;
+    }
+
+    if let Err(swap_error) = fs::rename(module_dir, &active_dir) {
+        if had_active {
+            if let Err(restore_error) = fs::rename(&backup_dir, &active_dir) {
+                error!(
+                    "Hot-plug rollback failed for \"{}\": swap={}, restore={}",
+                    name, swap_error, restore_error
+                );
+            }
+        }
+        return Err(swap_error).with_context(|| {
+            format!("failed to move staged module into {}", active_dir.display())
+        });
+    }
+
+    if had_active {
+        if let Err(e) = fs::remove_dir_all(&backup_dir) {
+            warn!(
+                "Hot-plug: could not remove backup {}: {}",
+                backup_dir.display(),
+                e
+            );
+        }
+    }
+
+    clear_activation_markers(name);
+    write_activation_marker(name, "applying");
+    info!(
+        "Hot-plug: swapped staged module \"{}\" into the active directory",
+        name
+    );
+    Ok(active_dir)
 }
 
 /// Names and directories of every module eligible for Zygisk injection,
@@ -341,12 +499,26 @@ fn eligible_modules(arch: &str) -> Vec<(String, PathBuf)> {
             let name = entry.file_name().into_string().unwrap_or_default();
             let module_dir = entry.path();
             if module_dir.join(format!("zygisk/{arch}.so")).exists() {
-                let disabled = module_dir.join("disable").exists();
+                // Once a module was moved into the active directory by our
+                // hot-plug transaction, its per-module switch remains
+                // authoritative.  Turning the switch off must actually stop
+                // serving the library to newly forked processes; merely
+                // removing the preference file while continuing to enumerate
+                // every active module made "unplug" ineffective.
+                let was_hotplugged = activation_marker(&name, "post_fs_data").exists();
+                if was_hotplugged && !hotplug_opted_in(&name) {
+                    continue;
+                }
+                let disabled =
+                    module_dir.join("disable").exists() || module_dir.join("remove").exists();
                 modules.insert(name, (module_dir, disabled));
             }
         }
     } else {
-        warn!("Failed to read modules directory: {}", constants::PATH_MODULES_DIR);
+        warn!(
+            "Failed to read modules directory: {}",
+            constants::PATH_MODULES_DIR
+        );
     }
 
     // Unplug: a module that was hot-plugged into the active directory stays
@@ -505,6 +677,129 @@ fn run_module_script(module_dir: &Path, script: &Path) {
     }
 }
 
+fn parse_daemon_nice_name(script: &str) -> Option<String> {
+    let marker = "--nice-name=";
+    let start = script.find(marker)? + marker.len();
+    let rest = &script[start..];
+    let end = rest
+        .find(|c: char| c.is_whitespace() || c == '"' || c == '\'' || c == '\\')
+        .unwrap_or(rest.len());
+    let name = rest[..end].trim();
+    (!name.is_empty()).then(|| name.to_string())
+}
+
+fn process_cmdline_matches<F>(mut pred: F) -> bool
+where
+    F: FnMut(&[String]) -> bool,
+{
+    let Ok(dir) = fs::read_dir("/proc") else {
+        return false;
+    };
+    for entry in dir.flatten() {
+        if entry.file_name().to_string_lossy().parse::<i32>().is_err() {
+            continue;
+        }
+        let Ok(cmdline) = fs::read(entry.path().join("cmdline")) else {
+            continue;
+        };
+        if cmdline.is_empty() {
+            continue;
+        }
+        let args: Vec<String> = cmdline
+            .split(|b| *b == 0)
+            .filter(|s| !s.is_empty())
+            .map(|s| String::from_utf8_lossy(s).into_owned())
+            .collect();
+        if pred(&args) {
+            return true;
+        }
+    }
+    false
+}
+
+fn module_daemon_running(module_dir: &Path, nice_name: Option<&str>) -> bool {
+    let daemon_path = module_dir.join("daemon").to_string_lossy().into_owned();
+    process_cmdline_matches(|args| {
+        if let Some(first) = args.first() {
+            if nice_name.is_some_and(|name| first == name) {
+                return true;
+            }
+        }
+        args.iter().any(|arg| arg == &daemon_path)
+    })
+}
+
+/// Some modules start a long-lived daemon from service.sh and swallow its
+/// stderr (Vector's daemon redirects app_process to /dev/null). If service.sh
+/// was invoked from a live hot-plug transaction but the daemon process never
+/// appears, retry the module's daemon directly from the real active directory
+/// and keep its early stderr in WORKDIR/hotplug_activated/<id>.daemon.log.
+fn ensure_module_daemon_started(name: &str, module_dir: &Path) {
+    let daemon = module_dir.join("daemon");
+    if !daemon.is_file() {
+        return;
+    }
+
+    let script = fs::read_to_string(&daemon).unwrap_or_default();
+    let nice_name = parse_daemon_nice_name(&script);
+    thread::sleep(Duration::from_secs(1));
+    if module_daemon_running(module_dir, nice_name.as_deref()) {
+        info!(
+            "Hot-plug: daemon for \"{}\" is running{}",
+            name,
+            nice_name
+                .as_deref()
+                .map(|n| format!(" ({n})"))
+                .unwrap_or_default()
+        );
+        return;
+    }
+
+    warn!(
+        "Hot-plug: daemon for \"{}\" did not appear after service.sh; retrying direct start",
+        name
+    );
+    let log_path = activation_marker(name, "daemon.log");
+    let log_file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .ok();
+    let stdout = log_file
+        .as_ref()
+        .and_then(|file| file.try_clone().ok())
+        .map(Stdio::from)
+        .unwrap_or_else(Stdio::null);
+    let stderr = log_file
+        .map(Stdio::from)
+        .unwrap_or_else(Stdio::null);
+
+    let mut command = Command::new("sh");
+    command.arg(&daemon);
+    if script.contains("system-server-max-retry") || nice_name.as_deref() == Some("vectord") {
+        command.arg("--system-server-max-retry=3");
+    }
+
+    match command
+        .current_dir(module_dir)
+        .env("MODDIR", module_dir)
+        .stdin(Stdio::null())
+        .stdout(stdout)
+        .stderr(stderr)
+        .spawn()
+    {
+        Ok(child) => info!(
+            "Hot-plug: spawned fallback daemon for \"{}\" as pid {}",
+            name,
+            child.id()
+        ),
+        Err(e) => warn!(
+            "Hot-plug: failed to spawn fallback daemon for \"{}\": {}",
+            name, e
+        ),
+    }
+}
+
 /// Whether system_server is up enough for `service.sh`-stage daemons (lspd
 /// etc.) to start safely — they crash on an unprepared framework.
 ///
@@ -556,66 +851,116 @@ fn system_server_ready() -> bool {
 /// active dir, and the root solution's next boot-time swap finds nothing
 /// left in modules_update/.
 fn activate_staged_module(name: &str, module_dir: &Path) {
-    let active_dir = Path::new(constants::PATH_MODULES_DIR).join(name);
-    // Swap the staged copy into the active directory (preserving a possible
-    // disable flag from the active stub, like the boot-time swap inherits
-    // the disabled state).
-    if let Ok(md) = fs::metadata(&active_dir) {
-        if md.is_dir() {
-            let _ = fs::rename(active_dir.join("disable"), module_dir.join("disable"));
-            let _ = fs::remove_dir_all(&active_dir);
+    let dir = match swap_staged_module(name, module_dir) {
+        Ok(dir) => dir,
+        Err(e) => {
+            warn!(
+                "Hot-plug: failed to activate staged module \"{}\": {:#}",
+                name, e
+            );
+            return;
         }
-    }
-    if let Err(e) = fs::rename(module_dir, &active_dir) {
-        warn!(
-            "Hot-plug: failed to swap staged module \"{}\" into {}: {}",
-            name, active_dir.display(), e
-        );
-        return;
-    }
-    info!("Hot-plug: swapped staged module \"{}\" into the active directory", name);
+    };
 
-    let dir = active_dir;
-    let marker_post = Path::new(TMP_PATH.get().unwrap())
-        .join("hotplug_activated")
-        .join(format!("{name}.post_fs_data"));
-    if !marker_post.exists() {
-        let dir_clone = dir.clone();
-        let marker_clone = marker_post.clone();
-        std::thread::spawn(move || {
-            let p = dir_clone.join("post-fs-data.sh");
-            if p.is_file() {
-                run_module_script(&dir_clone, &p);
+    let name = name.to_string();
+    info!(
+        "Hot-plug: scheduling lifecycle scripts for swapped module \"{}\"",
+        name
+    );
+    std::thread::spawn(move || {
+        let post = dir.join("post-fs-data.sh");
+        if post.is_file() {
+            run_module_script(&dir, &post);
+        }
+        write_activation_marker(&name, "post_fs_data");
+
+        if system_server_ready() {
+            let service = dir.join("service.sh");
+            if service.is_file() {
+                run_module_script(&dir, &service);
             }
-            if let Some(parent) = marker_clone.parent() {
-                let _ = fs::create_dir_all(parent);
-            }
-            let _ = fs::write(&marker_clone, b"1");
-        });
+            ensure_module_daemon_started(&name, &dir);
+            write_activation_marker(&name, "service");
+            let _ = fs::write(activation_marker(&name, "state"), b"1");
+            let _ = fs::remove_file(activation_marker(&name, "applying"));
+            refresh_controller_info();
+            reboot_device_to_activate(&name, false);
+        } else {
+            // run_pending_staged_services() finishes service + restart later.
+            let _ = fs::remove_file(activation_marker(&name, "applying"));
+        }
+    });
+}
+
+/// Apply the WebUI's current per-module hot-plug preference immediately.
+pub fn apply_hotplug(tmp_path: Option<&str>, name: &str) -> Result<()> {
+    initialize_globals(tmp_path)?;
+    if !valid_module_id(name) {
+        bail!("invalid hot-plug module id: {name}");
     }
-    let marker_svc = Path::new(TMP_PATH.get().unwrap())
-        .join("hotplug_activated")
-        .join(format!("{name}.service"));
-    if !marker_svc.exists() && system_server_ready() {
-        let dir_clone = dir.clone();
-        let marker_clone = marker_svc.clone();
-        let name_clone = name.to_string();
-        std::thread::spawn(move || {
-            let p = dir_clone.join("service.sh");
-            if p.is_file() {
-                run_module_script(&dir_clone, &p);
-            }
-            if let Some(parent) = marker_clone.parent() {
-                let _ = fs::create_dir_all(parent);
-            }
-            let _ = fs::write(&marker_clone, b"1");
-            // lspd (and any service.sh daemon) is now up. Re-fork
-            // system_server once so this freshly hot-plugged framework module
-            // loads at specialize and actually activates — no full reboot.
-            restart_system_server_once(&name_clone);
-        });
-        info!("Hot-plug: scheduling service.sh for swapped module \"{}\"", name);
+
+    let enabled = hotplug_opted_in(name);
+    if enabled && !hotplug_master_enabled() {
+        bail!("hot-plug master switch is disabled");
     }
+
+    let active_dir = Path::new(constants::PATH_MODULES_DIR).join(name);
+    if enabled && (active_dir.join("disable").exists() || active_dir.join("remove").exists()) {
+        bail!("module {name} is disabled or pending removal");
+    }
+    let mut swapped = false;
+    if enabled && staged_update_ready(name) {
+        let staged_dir = Path::new(constants::PATH_MODULES_UPDATE_DIR).join(name);
+        swap_staged_module(name, &staged_dir)?;
+        swapped = true;
+    }
+
+    if enabled && !active_dir.is_dir() {
+        bail!("module {name} is not installed in the active directory");
+    }
+
+    if swapped {
+        let post = active_dir.join("post-fs-data.sh");
+        if post.is_file() {
+            run_module_script(&active_dir, &post);
+        }
+        write_activation_marker(name, "post_fs_data");
+
+        if !system_server_ready() {
+            let _ = fs::remove_file(activation_marker(name, "applying"));
+            bail!("system_server is not ready; service activation was deferred");
+        }
+        let service = active_dir.join("service.sh");
+        if service.is_file() {
+            run_module_script(&active_dir, &service);
+        }
+        ensure_module_daemon_started(name, &active_dir);
+        write_activation_marker(name, "service");
+        let _ = fs::remove_file(activation_marker(name, "applying"));
+    }
+
+    // The WebUI writes the preference before invoking this CLI.  Persist the
+    // last setting that was actually applied so retries (WebView reconnect,
+    // double event delivery, or two root bridges) are idempotent and cannot
+    // restart a freshly respawned system_server again.
+    let state_marker = activation_marker(name, "state");
+    let target_state = if enabled { "1" } else { "0" };
+    let previous_state = fs::read_to_string(&state_marker).unwrap_or_default();
+    let state_changed = swapped || previous_state.trim() != target_state;
+    fs::write(&state_marker, target_state.as_bytes())?;
+
+    refresh_controller_info();
+    if !state_changed {
+        info!(
+            "Hot-plug: module \"{}\" is already in the requested state; skipping duplicate restart",
+            name
+        );
+        return Ok(());
+    }
+    if !reboot_device_to_activate(name, true) {
+        bail!("device could not be rebooted to apply the change");
+    }
+    Ok(())
 }
 
 /// Opted-in staged modules (master switch on, staged copy complete, per-module
@@ -665,36 +1010,230 @@ fn pidof_system_server() -> Option<i32> {
     None
 }
 
-/// Restart just system_server (a ~15s framework "soft reboot", not a device
-/// reboot) so a freshly hot-plugged framework module (LSPosed) is loaded at
-/// the fresh fork/specialize — the ONLY point a framework module activates.
-/// Killing system_server makes init respawn zygote's system_server; our
-/// nativeForkSystemServer hook then injects the now-active module the normal,
-/// crash-free way. Guarded by a one-shot marker so it happens once per
-/// hot-plug, never on an ordinary boot (where the module is already active and
-/// no swap runs).
-fn restart_system_server_once(name: &str) {
-    let marker = Path::new(TMP_PATH.get().unwrap())
-        .join("hotplug_activated")
-        .join(format!("{name}.restarted"));
-    if marker.exists() {
+fn hotplug_restart_guard() -> PathBuf {
+    Path::new(TMP_PATH.get().unwrap()).join("hotplug_restart_guard")
+}
+
+/// Startup half of the hot-plug circuit breaker.
+///
+/// `handle_hotplug_restart_guard` can only advance while the daemon is alive
+/// to see `SystemServerStarted` events, so every boot re-evaluates whatever
+/// guard the previous session left behind (post-fs-data deliberately no
+/// longer deletes it):
+///
+/// - `rebooting` — this boot IS the intentional cold reboot that activates
+///   the module.  Keep the module active and advance to `confirming`; the
+///   first SystemServerStarted of this boot will move it to `observing`.
+/// - `confirming` — the device rebooted AGAIN before the framework ever
+///   confirmed itself: the module broke the boot path (e.g. a zygote crash
+///   escalated by init).  Unplug it before its library is served anywhere.
+/// - `armed`/`observing` — a full reboot crossed the restart/stability
+///   window (crash evidence, e.g. `zygote reboot by service`).  Unplug.
+///
+/// Better one false positive (the user re-enables the switch) than an
+/// infinite boot loop.
+fn resolve_stale_restart_guard() {
+    let guard = hotplug_restart_guard();
+    let Ok(content) = fs::read_to_string(&guard) else {
+        return; // No guard: the previous session ended cleanly.
+    };
+    let mut parts = content.trim().splitn(3, ':');
+    let (stage, name) = (parts.next().unwrap_or(""), parts.next().unwrap_or(""));
+    let recorded_pid = parts.next().unwrap_or("").trim();
+    if !valid_module_id(name) {
+        let _ = fs::remove_file(&guard);
         return;
     }
-    if let Some(parent) = marker.parent() {
-        let _ = fs::create_dir_all(parent);
+    match stage {
+        "rebooting" => {
+            info!(
+                "Hot-plug: booting to activate module \"{}\"; awaiting framework confirmation",
+                name
+            );
+            let _ = fs::write(&guard, format!("confirming:{name}:{recorded_pid}").as_bytes());
+        }
+        "confirming" | "armed" | "observing" => {
+            error!(
+                "Hot-plug: restart guard \"{}:{}\" survived a reboot; unplugging module \"{}\" as the likely crash cause",
+                stage, name, name
+            );
+            let _ = fs::remove_file(
+                Path::new(TMP_PATH.get().unwrap())
+                    .join("hotplug")
+                    .join(name),
+            );
+            let _ = fs::write(activation_marker(name, "state"), b"0");
+            let _ = fs::write(activation_marker(name, "crash_blocked"), b"1");
+            let _ = fs::remove_file(&guard);
+        }
+        _ => {
+            let _ = fs::remove_file(&guard);
+        }
     }
-    let _ = fs::write(&marker, b"1");
+}
+
+/// Circuit breaker for a module that makes system_server crash immediately
+/// after hot-plugging.  The first SystemServerStarted after our intentional
+/// reboot (guard stage `armed` from older builds, `rebooting`/`confirming`
+/// now) begins a stability window.  A second, different PID inside that
+/// window means the framework restarted again without a user request: unplug
+/// the module before allowing another specialize so the device can recover.
+fn handle_hotplug_restart_guard() {
+    let guard = hotplug_restart_guard();
+    let Ok(contents) = fs::read_to_string(&guard) else {
+        return;
+    };
+    let mut parts = contents.trim().split(':');
+    let Some(stage) = parts.next() else { return };
+    let Some(name) = parts.next() else { return };
+    let Some(recorded_pid) = parts.next().and_then(|p| p.parse::<i32>().ok()) else {
+        return;
+    };
+    if !valid_module_id(name) {
+        let _ = fs::remove_file(&guard);
+        return;
+    }
+    let Some(current_pid) = pidof_system_server() else {
+        return;
+    };
+
+    if matches!(stage, "armed" | "rebooting" | "confirming") {
+        if current_pid == recorded_pid {
+            return;
+        }
+        let observing = format!("observing:{name}:{current_pid}");
+        if fs::write(&guard, observing.as_bytes()).is_err() {
+            return;
+        }
+        let guard_clone = guard.clone();
+        let name_clone = name.to_string();
+        thread::spawn(move || {
+            thread::sleep(Duration::from_secs(30));
+            let expected = format!("observing:{name_clone}:{current_pid}");
+            if fs::read_to_string(&guard_clone)
+                .map(|value| value.trim() == expected)
+                .unwrap_or(false)
+                && pidof_system_server() == Some(current_pid)
+            {
+                let _ = fs::remove_file(&guard_clone);
+                info!(
+                    "Hot-plug: system_server pid {} remained stable after activating \"{}\"",
+                    current_pid, name_clone
+                );
+            }
+        });
+        return;
+    }
+
+    if stage != "observing" || current_pid == recorded_pid {
+        return;
+    }
+
+    warn!(
+        "Hot-plug: detected system_server restart loop after activating \"{}\"; automatically unplugging it",
+        name
+    );
+    let _ = fs::remove_file(
+        Path::new(TMP_PATH.get().unwrap())
+            .join("hotplug")
+            .join(name),
+    );
+    let _ = fs::write(activation_marker(name, "state"), b"0");
+    let _ = fs::write(activation_marker(name, "crash_blocked"), b"1");
+    let _ = fs::remove_file(&guard);
+    refresh_controller_info();
+
+    // This instance was already specialized with the bad module before it
+    // could report SystemServerStarted.  Terminate it once; the following
+    // instance is served from the now-unplugged module list and the guard is
+    // gone, so this cannot form another Onyx-triggered loop.
+    let _ = unsafe { libc::kill(current_pid, libc::SIGKILL) };
+}
+
+/// Activate a freshly hot-plugged framework module (LSPosed) by rebooting
+/// the device.  The module must be loaded at the fresh system_server
+/// fork/specialize — the ONLY point a framework module activates — and we
+/// used to get that cheaply by killing system_server (a ~15s framework
+/// "soft reboot").  That proved unsafe: a module that misbehaves on the
+/// soft-restarted framework makes zygote/netd restart repeatedly, and
+/// Android init escalates that into a hard reboot — looping the device.
+/// A full cold reboot re-runs the entire injection chain against a fresh
+/// zygote — the same, well-tested path a module takes after a normal
+/// install — and reliably lands the module in the new system_server.
+///
+/// Guarded by a one-shot marker so it happens once per hot-plug, never on
+/// an ordinary boot (where the module is already active and no swap runs).
+fn reboot_device_to_activate(name: &str, force: bool) -> bool {
+    // Serialize marker inspection and PID reservation across the 32/64-bit
+    // daemons plus WebUI CLI processes.  The old check-then-kill sequence was
+    // racy: several concurrent module scans could all observe a missing marker
+    // and kill system_server in succession.
+    let _lock = match acquire_hotplug_lock() {
+        Ok(lock) => lock,
+        Err(e) => {
+            warn!("Hot-plug: failed to lock system_server restart: {}", e);
+            return false;
+        }
+    };
+    let marker = activation_marker(name, "restarted");
+    if marker.exists() && !force {
+        return true;
+    }
     match pidof_system_server() {
         Some(pid) => {
-            info!(
-                "Hot-plug: restarting system_server (pid {}) to activate framework module \"{}\"",
-                pid, name
-            );
-            unsafe {
-                libc::kill(pid, libc::SIGKILL);
+            // Reserve this exact system_server generation before triggering
+            // the reboot.  A duplicate explicit request racing with us sees
+            // the same PID in the marker and becomes a no-op.  A later
+            // legitimate state transition sees a different PID and may
+            // reboot once.
+            if fs::read_to_string(&marker)
+                .ok()
+                .and_then(|value| value.trim().parse::<i32>().ok())
+                == Some(pid)
+            {
+                info!(
+                    "Hot-plug: system_server pid {} was already reserved for restart",
+                    pid
+                );
+                return true;
             }
+            if fs::write(&marker, pid.to_string().as_bytes()).is_err() {
+                warn!("Hot-plug: failed to reserve system_server restart marker");
+                return false;
+            }
+            // Mark the reboot as intentional: resolve_stale_restart_guard
+            // turns this into "confirming" at the next boot, so only a
+            // framework that then fails to stabilize gets the module
+            // unplugged.
+            let guard = format!("rebooting:{name}:{pid}");
+            if fs::write(hotplug_restart_guard(), guard.as_bytes()).is_err() {
+                let _ = fs::remove_file(&marker);
+                warn!("Hot-plug: failed to arm the system_server restart guard");
+                return false;
+            }
+            info!(
+                "Hot-plug: rebooting device to activate framework module \"{}\" (system_server pid {})",
+                name, pid
+            );
+            // Graceful reboot via init (stops services, syncs, unmounts).
+            // Fall back to the toybox reboot binary if the property cannot
+            // be set.
+            if let Err(e) = utils::set_property("sys.powerctl", "reboot") {
+                warn!(
+                    "Hot-plug: sys.powerctl reboot failed ({}); falling back to `reboot`",
+                    e
+                );
+                let _ = Command::new("reboot").status();
+            }
+            true
         }
-        None => warn!("Hot-plug: system_server pid not found; cannot restart to activate \"{}\"", name),
+        None => {
+            warn!(
+                "Hot-plug: system_server pid not found; cannot reboot to activate \"{}\"",
+                name
+            );
+            false
+        }
     }
 }
 
@@ -721,21 +1260,40 @@ fn run_pending_staged_services() {
         if !has_so {
             continue;
         }
+        // Atomically claim the deferred lifecycle job before spawning it.
+        // load_modules() is called concurrently by many forks, so checking a
+        // marker without creating it here schedules service.sh many times.
+        let applying = markers.join(format!("{name}.applying"));
+        match fs::OpenOptions::new().write(true).create_new(true).open(&applying) {
+            Ok(_) => {}
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => continue,
+            Err(e) => {
+                warn!("Hot-plug: failed to claim deferred service for \"{}\": {}", name, e);
+                continue;
+            }
+        }
         let dir_clone = active_dir.clone();
         let marker_clone = markers.join(format!("{name}.service"));
+        let applying_clone = applying.clone();
         let name_clone = name.to_string();
         std::thread::spawn(move || {
             let p = dir_clone.join("service.sh");
             if p.is_file() {
                 run_module_script(&dir_clone, &p);
             }
+            ensure_module_daemon_started(&name_clone, &dir_clone);
             let _ = fs::write(&marker_clone, b"1");
-            // Re-fork system_server once so this freshly hot-plugged framework
-            // module activates at specialize — no full reboot. See
-            // restart_system_server_once.
-            restart_system_server_once(&name_clone);
+            let _ = fs::write(activation_marker(&name_clone, "state"), b"1");
+            let _ = fs::remove_file(&applying_clone);
+            // Reboot once so this freshly hot-plugged framework module
+            // activates at specialize. See reboot_device_to_activate.
+            refresh_controller_info();
+            reboot_device_to_activate(&name_clone, false);
         });
-        info!("Hot-plug: scheduling deferred service.sh for swapped module \"{}\"", name);
+        info!(
+            "Hot-plug: scheduling deferred service.sh for swapped module \"{}\"",
+            name
+        );
     }
 }
 
@@ -887,7 +1445,7 @@ fn handle_update_mount_namespace(stream: &mut UnixStream, context: &AppContext) 
         stream.write_u8(1)?;
         stream.send_fd(fd)?;
     } else {
-        // FAILURE: Send Status '0'. 
+        // FAILURE: Send Status '0'.
         // Do NOT send an FD or random u32 bytes, just stop here.
         warn!("Namespace {:?} is not cached yet.", namespace_type);
         stream.write_u8(0)?;
@@ -956,7 +1514,10 @@ fn handle_request_companion_socket(stream: &mut UnixStream, context: &AppContext
     // Send the companion FD to the client if available.
     if let Some(sock) = companion.as_ref() {
         if let Err(e) = sock.send_fd(stream.as_raw_fd()) {
-            error!("Failed to send companion socket FD for module `{}`: {}", name, e);
+            error!(
+                "Failed to send companion socket FD for module `{}`: {}",
+                name, e
+            );
             // Inform client of failure.
             stream.write_u8(0)?;
         }
@@ -990,7 +1551,10 @@ fn handle_request_fn_companion_socket(
     let mut companion = cell.lock().unwrap();
     if let Some(sock) = companion.as_ref() {
         if !utils::is_socket_alive(sock) {
-            error!("Companion for FN node `{}` appears to have crashed.", node.id);
+            error!(
+                "Companion for FN node `{}` appears to have crashed.",
+                node.id
+            );
             companion.take();
         }
     }
@@ -1001,7 +1565,10 @@ fn handle_request_fn_companion_socket(
                 *companion = Some(sock);
             }
             Ok(None) => {
-                warn!("FN node `{}` does not have a companion entry point.", node.id);
+                warn!(
+                    "FN node `{}` does not have a companion entry point.",
+                    node.id
+                );
             }
             Err(e) => {
                 warn!("Failed to spawn companion for FN node `{}`: {}", node.id, e);

--- a/zygiskd/webui/package.json
+++ b/zygiskd/webui/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "type": "module",
-  "description": "OnyxZygisk WebUI — Vue 3 + Vite + TypeScript, built into the module's webroot/",
+  "description": "OnyxZygisk WebUI - Vue 3 + Vite + TypeScript, built into the module's webroot/",
   "packageManager": "pnpm@11.17.0",
   "scripts": {
     "dev": "vite",

--- a/zygiskd/webui/src/App.test.ts
+++ b/zygiskd/webui/src/App.test.ts
@@ -55,6 +55,27 @@ describe("App hero", () => {
     wrapper.unmount();
   });
 
+  it("shows installed instead of unknown before the runtime status file exists", async () => {
+    vi.mocked(fetchState).mockResolvedValue(
+      state({
+        keys: {
+          root: "KernelSU",
+          version: "1.0",
+          installed: "1",
+          runtime: "0",
+          daemon: "0",
+        },
+        monitor: "",
+      }),
+    );
+
+    const wrapper = mount(App, { global: { stubs } });
+    await flushPromises();
+    expect(wrapper.find(".badge").text()).toContain("Installed");
+    expect(wrapper.find(".badge").text()).not.toContain("Unknown");
+    wrapper.unmount();
+  });
+
   it("collapses to the compact style once scrolled past the threshold", async () => {
     const wrapper = mount(App, { global: { stubs } });
     await flushPromises();

--- a/zygiskd/webui/src/App.vue
+++ b/zygiskd/webui/src/App.vue
@@ -16,7 +16,7 @@ const { t, locale } = useLocale();
 
 const state = useMonitorState();
 provide(MONITOR_STATE_KEY, state);
-const { loading, error, monitor, rootImpl, version } = state;
+const { loading, error, monitor, rootImpl, version, installed, runtimeReady, daemonRunning } = state;
 
 function valClass(v: string): string {
   if (/not injected|stopped|exited|crashed|invalid/i.test(v)) return "err";
@@ -25,16 +25,49 @@ function valClass(v: string): string {
   return "";
 }
 
-/** Overall hero badge derived from the live monitor rows. */
+/** Overall hero badge derived from the live monitor rows.
+ *
+ * The `monitor` row is authoritative for whether the framework is running:
+ * `tracing` = up, `stopped`/`exited` = down. Sub-rows such as
+ * `zygote64: not injected` mean injection is merely *pending* — no app has
+ * forked since boot yet — NOT that the monitor stopped, so they must not, on
+ * their own, flip the hero to "stopped" (which previously happened the whole
+ * time between boot and the first fork, and whenever a second ABI had nothing
+ * to inject into). Only a stopped/exited monitor, or a crashed daemon, is a
+ * genuine "stopped".
+ */
 const overall = computed(() => {
   if (loading.value) return { key: "common.loading", cls: "badge--idle", spin: true };
   if (error.value) return { key: "status.error", cls: "badge--err", spin: false };
-  const vals = monitor.value.filter((r) => r.label).map((r) => r.value);
-  if (!vals.length) return { key: "status.unknown", cls: "badge--idle", spin: false };
-  if (vals.some((v) => valClass(v) === "err"))
+  const rows = monitor.value.filter((r) => r.label);
+  if (!rows.length) {
+    if (daemonRunning.value)
+      return { key: "status.working", cls: "badge--ok", spin: false };
+    if (installed.value)
+      return { key: "status.installed", cls: "badge--warn", spin: false };
+    return { key: "status.unknown", cls: "badge--idle", spin: false };
+  }
+
+  const monitorVal = rows.find((r) => r.label === "monitor")?.value ?? "";
+
+  // Genuinely-stopped states.
+  if (/stopped|exited/i.test(monitorVal))
     return { key: "status.stopped", cls: "badge--err", spin: false };
-  if (vals.some((v) => valClass(v) === "ok"))
+  if (rows.some((r) => /crashed/i.test(r.value)))
+    return { key: "status.stopped", cls: "badge--err", spin: false };
+
+  // Monitor is tracing → the framework is up and watching, so it reads as
+  // "working". A zygote that is not injected yet just means no app has forked
+  // since boot; that shows on its own detail row and must not water the hero
+  // down while the monitor is plainly running.
+  if (/tracing/i.test(monitorVal))
     return { key: "status.working", cls: "badge--ok", spin: false };
+
+  // No monitor row (older builds / partial status) but something reads healthy.
+  if (rows.some((r) => valClass(r.value) === "ok"))
+    return { key: "status.working", cls: "badge--ok", spin: false };
+  if (installed.value && !runtimeReady.value)
+    return { key: "status.installed", cls: "badge--warn", spin: false };
   return { key: "status.unknown", cls: "badge--warn", spin: false };
 });
 

--- a/zygiskd/webui/src/api/system.test.ts
+++ b/zygiskd/webui/src/api/system.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from "vitest";
-import { fmtVer, parseMonitor, parseStatus } from "./system";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../bridge", () => ({ exec: vi.fn() }));
+
+import { exec } from "../bridge";
+import { fetchLogs, fetchState, fmtVer, parseMonitor, parseStatus } from "./system";
+
+beforeEach(() => {
+  vi.mocked(exec).mockReset();
+});
 
 describe("parseStatus", () => {
   const sample = [
@@ -72,6 +80,58 @@ describe("parseStatus", () => {
     expect(d.monitor).toBe("");
     expect(d.modules).toEqual([]);
     expect(d.fns).toEqual([]);
+  });
+});
+
+describe("fetchState", () => {
+  it("accepts a complete status protocol even if the bridge reports a non-zero errno", async () => {
+    vi.mocked(exec).mockResolvedValue({
+      errno: 1,
+      stdout: "status_protocol=1\ninstalled=1\n@@monitor\n\tmonitor:\ttracing\n@@modules\n@@fn",
+      stderr: "",
+    });
+
+    const data = await fetchState();
+    expect(data.keys.installed).toBe("1");
+    expect(data.monitor).toContain("monitor:");
+  });
+
+  it("rejects output without the protocol marker", async () => {
+    vi.mocked(exec).mockResolvedValue({ errno: 1, stdout: "shell failed", stderr: "" });
+    await expect(fetchState()).rejects.toThrow("shell failed");
+  });
+});
+
+describe("fetchLogs", () => {
+  it("uses logcat stdout even when the bridge reports a non-zero errno", async () => {
+    vi.mocked(exec).mockResolvedValue({
+      errno: 1,
+      stdout: "I/zygiskd: Hot-plug: swapped staged module\n",
+      stderr: "",
+    });
+
+    await expect(fetchLogs(200)).resolves.toBe("I/zygiskd: Hot-plug: swapped staged module");
+    expect(vi.mocked(exec).mock.calls[0][0]).toContain("-s zygiskd:* zygisk-sh:*");
+    expect(vi.mocked(exec).mock.calls[0][0]).not.toContain("zygisk-core");
+  });
+
+  it("falls back to KernelSU log snapshots when logcat is unavailable", async () => {
+    vi.mocked(exec)
+      .mockResolvedValueOnce({ errno: 1, stdout: "", stderr: "logcat denied" })
+      .mockResolvedValueOnce({ errno: 0, stdout: "I/zygiskd: Module script stdout\n", stderr: "" });
+
+    await expect(fetchLogs(200)).resolves.toBe("I/zygiskd: Module script stdout");
+    expect(vi.mocked(exec).mock.calls[1][0]).toContain("/data/adb/ksu/log/logcat.log");
+    expect(vi.mocked(exec).mock.calls[1][0]).toContain('tail -n "$read"');
+    expect(vi.mocked(exec).mock.calls[1][0]).toContain('grep -E "zygiskd|zygisk-sh"');
+  });
+
+  it("returns an empty log instead of an error when no log source is readable", async () => {
+    vi.mocked(exec)
+      .mockResolvedValueOnce({ errno: 1, stdout: "", stderr: "logcat denied" })
+      .mockResolvedValueOnce({ errno: 0, stdout: "", stderr: "" });
+
+    await expect(fetchLogs(200)).resolves.toBe("");
   });
 });
 

--- a/zygiskd/webui/src/api/system.ts
+++ b/zygiskd/webui/src/api/system.ts
@@ -1,12 +1,31 @@
 /* OnyxZygisk — data layer. One shell round-trip fetches full system state. */
 import { exec } from "../bridge";
-import type { FnNodeInfo, ModuleInfo, MonitorRow, StateData } from "../types";
+import type { ExecResult, FnNodeInfo, ModuleInfo, MonitorRow, StateData } from "../types";
 
 const WORKDIR = "/data/adb/onyxzygisk";
 const MODDIR = "/data/adb/modules/onyxzygisk";
+const STAGED_MODDIR = "/data/adb/modules_update/onyxzygisk";
+const MODULE_LOG_PATTERN = [
+  "Hot-plug",
+  "hot-plug",
+  "zygiskd: hot-plug",
+  "Module script",
+  "FN ",
+  "Installing FN",
+  "Updating FN",
+  "Removed FN",
+  "Enabled FN",
+  "Disabled FN",
+  "Scheduling FN",
+  "Scheduled [0-9]+ FN",
+  "runtime module status",
+  "mount mode",
+  "daemon failed",
+].join("|");
 
 const STATUS_SCRIPT = [
-  'MOD="' + MODDIR + '"; W="' + WORKDIR + '"',
+  'ACTIVE="' + MODDIR + '"; STAGED="' + STAGED_MODDIR + '"; W="' + WORKDIR + '"',
+  'MOD="$ACTIVE"; [ -f "$MOD/module.prop" ] || MOD="$STAGED"',
   'v=$(sed -n "s/^version=//p" "$MOD/module.prop" 2>/dev/null | head -n1)',
   "r=none",
   // Root provider detection: only a RUNNING daemon counts. Stale files from a
@@ -20,6 +39,9 @@ const STATUS_SCRIPT = [
   "pidof magiskd >/dev/null 2>&1 && r=Magisk",
   // Print an empty label instead of "none" when nothing was detected.
   '[ "$r" = none ] && r=',
+  'echo "status_protocol=1"',
+  'echo "installed=$([ -f "$MOD/module.prop" ] && echo 1 || echo 0)"',
+  'echo "runtime=$([ -s "$W/module.prop" ] && echo 1 || echo 0)"',
   'echo "version=$v"; echo "root=$r"',
   'pidof zygote64 >/dev/null 2>&1 && echo "z64=1" || echo "z64=0"',
   '(pidof zygote >/dev/null 2>&1 || pidof zygote_secondary >/dev/null 2>&1) && echo "z32=1" || echo "z32=0"',
@@ -58,13 +80,13 @@ const STATUS_SCRIPT = [
   // practice (ksud leaves only a metadata stub in modules/<id>, apd's global
   // flag is cleared at boot), so file completeness is the signal.
   '    pend=0',
-  '    [ -f "$ud/module.prop" ] && { [ -f "$ud/zygisk/arm64-v8a.so" ] || [ -f "$ud/zygisk/armeabi-v7a.so" ]; } && pend=1',
+  '    [ -f "$ud/module.prop" ] && { [ -f "$ud/zygisk/arm64-v8a.so" ] || [ -f "$ud/zygisk/armeabi-v7a.so" ] || [ -f "$ud/zygisk/x86_64.so" ] || [ -f "$ud/zygisk/x86.so" ]; } && pend=1',
   // Read metadata + the .so from the staged copy when a staged update is
   // present (it is the version that will run once applied), else the active
   // copy. `dis` always comes from the active dir — the disable flag lives
   // there and the daemon inherits it across the swap.
   '    msrc="$ad"; [ "$pend" = 1 ] && [ -f "$ud/module.prop" ] && msrc="$ud"',
-  '    zsrc="$ad"; [ "$pend" = 1 ] && { [ -f "$ud/zygisk/arm64-v8a.so" ] || [ -f "$ud/zygisk/armeabi-v7a.so" ]; } && zsrc="$ud"',
+  '    zsrc="$ad"; [ "$pend" = 1 ] && zsrc="$ud"',
   '    p="$msrc/module.prop"; [ -f "$p" ] || continue',
   '    zy=0; { [ -f "$zsrc/zygisk/arm64-v8a.so" ] || [ -f "$zsrc/zygisk/armeabi-v7a.so" ]; } && zy=1',
   // Only Zygisk-capable modules are shown in the WebUI.
@@ -73,7 +95,7 @@ const STATUS_SCRIPT = [
   '    ver=$(sed -n "s/^version=//p" "$p" | head -n1)',
   '    au=$(sed -n "s/^author=//p" "$p" | head -n1)',
   '    ds=$(sed -n "s/^description=//p" "$p" | head -n1)',
-  '    dis=0; [ -f "$ad/disable" ] && dis=1',
+  '    dis=0; { [ -f "$ad/disable" ] || [ -f "$ad/remove" ]; } && dis=1',
   '    hp=0; [ -f "$W/hotplug/$id" ] && hp=1',
   // Was this module hot-plugged into the active directory? Such modules keep
   // a plug/unplug switch (hotplug flag present = plugged), independent of
@@ -92,6 +114,10 @@ const STATUS_SCRIPT = [
   '  st=enabled; [ -f "$d/disable" ] && st=disabled; [ -f "$d/remove" ] && st=pending_remove',
   '  echo "F|$id|$nm|$ver|$tr|$sc|$st"',
   "done",
+  // A glob with no FN directory can leave some Android shells with the test
+  // command's non-zero status even though the full protocol was emitted.
+  // Make the read-only status script explicitly successful.
+  ":",
   // Lines are joined with newlines, NOT "; ": a `; ` separator turns the
   // multi-line `for ...; do` loops into `do;` which is a shell syntax error.
 ].join("\n");
@@ -148,7 +174,25 @@ export function parseStatus(out: string): StateData {
 
 export async function fetchState(): Promise<StateData> {
   const r = await exec(STATUS_SCRIPT);
-  return parseStatus(r.stdout);
+  const data = parseStatus(r.stdout);
+  // The protocol marker is authoritative. A few root-manager shells report a
+  // non-zero callback errno after an otherwise complete multi-line script
+  // (notably when its final glob is empty), so rejecting solely on errno turns
+  // valid state into an error containing the entire status payload.
+  if (data.keys.status_protocol !== "1") {
+    const detail = (r.stdout || r.stderr).trim();
+    throw new Error(detail || `status command returned incomplete data (exit ${r.errno})`);
+  }
+  return data;
+}
+
+async function execChecked(cmd: string, operation: string): Promise<ExecResult> {
+  const r = await exec(cmd);
+  if (r.errno !== 0) {
+    const detail = (r.stdout || r.stderr).trim();
+    throw new Error(detail || `${operation} failed (exit ${r.errno})`);
+  }
+  return r;
 }
 
 /** Parse the monitor status section of the workdir module.prop.
@@ -173,25 +217,71 @@ export function parseMonitor(text: string): MonitorRow[] {
 }
 
 export async function fetchLogs(lines: number | string): Promise<string> {
-  const n = parseInt(String(lines), 10) || 200;
+  const parsed = parseInt(String(lines), 10);
+  const n = Math.min(300, Math.max(20, Number.isFinite(parsed) ? parsed : 120));
+  const readLimit = Math.min(500, Math.max(n * 3, 120));
   const r = await exec(
-    `logcat -d -v brief -t ${n} -s zygiskd:* zygisk-core64:* zygisk-core32:* zygisk-sh:* 2>/dev/null`,
+    `logcat -d -v brief -t ${readLimit} -s zygiskd:* zygisk-sh:* 2>/dev/null | grep -E '${MODULE_LOG_PATTERN}' | tail -n ${n}`,
   );
-  return r.stdout.trim();
+  const logcatOut = r.stdout.trim();
+  if (logcatOut || r.errno === 0) return logcatOut;
+
+  // Some root-manager WebUI bridges report a non-zero errno for `logcat`, or
+  // run in a context where logcat is unavailable. KernelSU already captures a
+  // full logcat snapshot, so fall back to that file instead of turning the log
+  // panel into a red error box.
+  const fallback = [
+    `n=${n}`,
+    `read=${readLimit}`,
+    `pat='${MODULE_LOG_PATTERN}'`,
+    "for f in /data/adb/ksu/log/logcat.log /data/adb/ksu/log/logcat.old.log; do",
+    '  [ -r "$f" ] || continue',
+    '  tail -n "$read" "$f" 2>/dev/null | grep -E "zygiskd|zygisk-sh" | grep -E "$pat" | tail -n "$n"',
+    "  exit 0",
+    "done",
+    ":",
+  ].join("\n");
+  const fb = await exec(fallback);
+  const fallbackOut = fb.stdout.trim();
+  if (fallbackOut || fb.errno === 0) return fallbackOut;
+
+  const detail = (r.stderr || fb.stderr || r.stdout || fb.stdout).trim();
+  throw new Error(detail || `read logs failed (exit ${r.errno})`);
 }
 
 export async function setFnEnabled(id: string, enabled: boolean): Promise<void> {
   const flag = `${WORKDIR}/fn/${id}/disable`;
-  await exec(enabled ? `rm -f '${flag}'` : `touch '${flag}'`);
+  await execChecked(enabled ? `rm -f '${flag}'` : `touch '${flag}'`, "update FN module");
 }
 
 /** Opt a module with a detected pending update into using it immediately —
  * the daemon only overlays a staged update when both this flag and the
  * hot-plug master switch are on. See zygiskd::eligible_modules. */
 export async function setModuleHotplug(id: string, enabled: boolean): Promise<void> {
+  if (!/^[A-Za-z0-9._-]+$/.test(id) || id === "." || id === "..") {
+    throw new Error("invalid module id");
+  }
   const dir = `${WORKDIR}/hotplug`;
   const flag = `${dir}/${id}`;
-  await exec(enabled ? `mkdir -p '${dir}' && touch '${flag}'` : `rm -f '${flag}'`);
+  await execChecked(
+    enabled ? `mkdir -p '${dir}' && touch '${flag}'` : `rm -f '${flag}'`,
+    "update hot-plug preference",
+  );
+
+  // Apply immediately through the bundled daemon CLI. It performs the staged
+  // -> active transaction, runs module lifecycle scripts, then reboots the
+  // device once so the module loads at the fresh system_server fork. Both
+  // ABIs are tried, including a staged OnyxZygisk update whose binary may
+  // not have moved into the active directory yet.
+  const apply = [
+    'bin=""',
+    `for b in '${MODDIR}/bin/zygiskd64' '${MODDIR}/bin/zygiskd32' '${STAGED_MODDIR}/bin/zygiskd64' '${STAGED_MODDIR}/bin/zygiskd32'; do`,
+    '  [ -x "$b" ] && { bin="$b"; break; }',
+    "done",
+    '[ -n "$bin" ] || { echo "OnyxZygisk daemon binary not found"; exit 127; }',
+    `"$bin" hotplug '${id}' --workdir '${WORKDIR}'`,
+  ].join("\n");
+  await execChecked(apply, "apply hot-plug module");
 }
 
 /** Master switch for the hot-plug feature. When off, per-module opt-ins are
@@ -200,7 +290,7 @@ export async function setModuleHotplug(id: string, enabled: boolean): Promise<vo
  * See zygiskd::hotplug_master_enabled. */
 export async function setHotplugMaster(enabled: boolean): Promise<void> {
   const flag = `${WORKDIR}/hotplug_off`;
-  await exec(enabled ? `rm -f '${flag}'` : `touch '${flag}'`);
+  await execChecked(enabled ? `rm -f '${flag}'` : `touch '${flag}'`, "update hot-plug setting");
 }
 
 /** Mount mode for denylisted apps, applied by the daemon/loader on the next
@@ -213,7 +303,10 @@ export type MountMode = "revert" | "setns" | "global";
 export async function setMountMode(mode: MountMode): Promise<void> {
   const flag = `${WORKDIR}/mount_mode`;
   // "revert" is the default — clear the file rather than storing it.
-  await exec(mode === "revert" ? `rm -f '${flag}'` : `printf '%s' '${mode}' > '${flag}'`);
+  await execChecked(
+    mode === "revert" ? `rm -f '${flag}'` : `printf '%s' '${mode}' > '${flag}'`,
+    "update mount mode",
+  );
 }
 
 /** Normalize version display: strip a leading v/V then add one. */

--- a/zygiskd/webui/src/bridge/index.ts
+++ b/zygiskd/webui/src/bridge/index.ts
@@ -82,7 +82,17 @@ function b64ToUtf8(b64: string): string {
 /** Execute a shell command; stdout is guaranteed correct UTF-8. */
 export async function exec(cmd: string): Promise<ExecResult> {
   if (!detectBridge()) return { errno: 0, stdout: devResponse(cmd), stderr: "" };
-  const wrapped = "{ " + cmd + " ; } 2>/dev/null | base64";
+  // Preserve the wrapped command's exit status. Piping straight into `base64`
+  // makes the pipeline report base64's (usually zero) status, which previously
+  // turned every failed write/hot-plug command into a fake success.
+  const wrapped = [
+    'out="$({',
+    cmd,
+    '} 2>&1)"',
+    "rc=$?",
+    'printf "%s" "$out" | base64',
+    'exit "$rc"',
+  ].join("\n");
   const r = await bridgeRaw(wrapped);
   return { errno: r.errno, stdout: b64ToUtf8(r.stdout), stderr: r.stderr };
 }

--- a/zygiskd/webui/src/bridge/mock.ts
+++ b/zygiskd/webui/src/bridge/mock.ts
@@ -50,11 +50,16 @@ export function devResponse(cmd: string): string {
   }
   if (cmd.indexOf("@@fn") !== -1) {
     return [
+      "status_protocol=1",
+      "installed=1",
+      "runtime=1",
       "version=1.0",
       "root=KernelSU",
       "z64=1",
       "z32=1",
       "daemon=1",
+      "hotplug=1",
+      "mount_mode=revert",
       "workdir=/data/adb/onyxzygisk",
       "@@monitor",
       "\tmonitor: \t tracing",

--- a/zygiskd/webui/src/components/LogsSection.vue
+++ b/zygiskd/webui/src/components/LogsSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-/* Logs section — the zygiskd / zygisk-core / zygisk-sh logcat view.
+/* Logs section - module operation log view.
  *
  * Auto-refresh keeps the scroll position stable so the view does not "jump"
  * while reading. Rows are parsed from the brief logcat format and colorized
@@ -17,7 +17,7 @@ import Toolbar from "./atoms/Toolbar.vue";
 const { t, locale } = useLocale();
 
 const out = ref<HTMLPreElement | null>(null);
-const lines = ref(200);
+const lines = ref(120);
 const auto = ref(true);
 const filter = ref("");
 const raw = ref("");
@@ -148,7 +148,7 @@ watch(filter, () => render());
       <Toolbar>
         <label class="log-lines"
           >{{ t("logs.lines") }}
-          <input type="number" v-model.number="lines" min="50" max="2000" />
+          <input type="number" v-model.number="lines" min="20" max="300" />
         </label>
         <label class="log-auto"
           ><input type="checkbox" v-model="auto" /> {{ t("logs.auto") }}</label

--- a/zygiskd/webui/src/components/ModulesSection.vue
+++ b/zygiskd/webui/src/components/ModulesSection.vue
@@ -22,10 +22,10 @@ async function toggleHotplug(m: ModuleInfo, enabled: boolean) {
   msg.value = "";
   try {
     await setModuleHotplug(m.id, enabled);
-    // No zygote restart: killing zygote makes the whole framework restart
-    // (a soft reboot) on some OEMs. The daemon serves the staged module to
-    // every process forked after this point, and the manager itself picks it
-    // up when reopened.
+    // The daemon CLI safely moves a staged module into the active directory,
+    // finishes its lifecycle scripts, and reboots the device once so the
+    // module loads at the fresh system_server fork. The manager/WebView
+    // closes as part of that intentional reboot.
     msg.value = t("modules.hotplugNote");
     await load();
   } catch (e) {
@@ -61,11 +61,12 @@ async function toggleHotplug(m: ModuleInfo, enabled: boolean) {
             >
               <span class="mod-row__hotplug-label">
                 {{ m.pendingUpdate ? t("modules.hotplug") : t("modules.hotplugToggle") }}
-                <span v-if="!hotplug" class="mod-row__hotplug-off">{{ t("modules.hotplugOff") }}</span>
+                <span v-if="m.disabled" class="mod-row__hotplug-off">{{ t("common.disabled") }}</span>
+                <span v-else-if="!hotplug" class="mod-row__hotplug-off">{{ t("modules.hotplugOff") }}</span>
               </span>
               <Switch
                 :checked="m.hotplugEnabled"
-                :disabled="!hotplug"
+                :disabled="!hotplug || m.disabled"
                 @update:checked="toggleHotplug(m, $event)"
               />
             </div>

--- a/zygiskd/webui/src/composables/useMonitorState.ts
+++ b/zygiskd/webui/src/composables/useMonitorState.ts
@@ -22,6 +22,9 @@ export interface MonitorState {
   fns: Ref<FnNodeInfo[]>;
   rootImpl: Ref<string>;
   version: Ref<string>;
+  installed: Ref<boolean>;
+  runtimeReady: Ref<boolean>;
+  daemonRunning: Ref<boolean>;
   hotplug: Ref<boolean>;
   mountMode: Ref<string>;
   load: () => Promise<void>;
@@ -35,6 +38,9 @@ export function useMonitorState(): MonitorState {
   const fns = ref<FnNodeInfo[]>([]);
   const rootImpl = ref("");
   const version = ref("");
+  const installed = ref(false);
+  const runtimeReady = ref(false);
+  const daemonRunning = ref(false);
   const hotplug = ref(true);
   const mountMode = ref("revert");
   const { locale } = useLocale();
@@ -46,6 +52,9 @@ export function useMonitorState(): MonitorState {
       const d = await fetchState();
       rootImpl.value = d.keys.root || "";
       version.value = d.keys.version || "";
+      installed.value = d.keys.installed === "1";
+      runtimeReady.value = d.keys.runtime === "1";
+      daemonRunning.value = d.keys.daemon === "1";
       hotplug.value = d.keys.hotplug !== "0";
       mountMode.value = d.keys.mount_mode || "revert";
       monitor.value = parseMonitor(d.monitor);
@@ -67,5 +76,19 @@ export function useMonitorState(): MonitorState {
   // Reload on language switch (dev mock data follows the locale).
   watch(locale, () => load());
 
-  return { loading, error, monitor, modules, fns, rootImpl, version, hotplug, mountMode, load };
+  return {
+    loading,
+    error,
+    monitor,
+    modules,
+    fns,
+    rootImpl,
+    version,
+    installed,
+    runtimeReady,
+    daemonRunning,
+    hotplug,
+    mountMode,
+    load,
+  };
 }

--- a/zygiskd/webui/src/locales/en_US.json
+++ b/zygiskd/webui/src/locales/en_US.json
@@ -25,6 +25,7 @@
     "running": "Running",
     "stopped": "Stopped",
     "working": "Working",
+    "installed": "Installed · runtime inactive",
     "unknown": "Unknown",
     "error": "Error",
     "none": "None",
@@ -37,7 +38,7 @@
     "pendingUpdate": "Update staged, not yet applied",
     "hotplug": "Apply now",
     "hotplugOff": "master off",
-    "hotplugNote": "Enabled — newly started apps will load this module",
+    "hotplugNote": "Applied; the device will now reboot to finish activation",
     "hotplugToggle": "Hot-plugged (unplug)"
   },
   "fn": {

--- a/zygiskd/webui/src/locales/ja_JP.json
+++ b/zygiskd/webui/src/locales/ja_JP.json
@@ -25,6 +25,7 @@
     "running": "実行中",
     "stopped": "停止中",
     "working": "稼働中",
+    "installed": "インストール済み · ランタイム未起動",
     "unknown": "不明",
     "error": "エラー",
     "none": "なし",
@@ -37,7 +38,7 @@
     "pendingUpdate": "更新が保留中です",
     "hotplug": "今すぐ適用",
     "hotplugOff": "無効",
-    "hotplugNote": "有効化しました。新しく起動するアプリに適用されます",
+    "hotplugNote": "適用しました。デバイスを再起動して有効化します",
     "hotplugToggle": "ホットプラグ済み（取り外し可）"
   },
   "fn": {

--- a/zygiskd/webui/src/locales/zh_CN.json
+++ b/zygiskd/webui/src/locales/zh_CN.json
@@ -25,6 +25,7 @@
     "running": "运行中",
     "stopped": "已停止",
     "working": "工作中",
+    "installed": "已安装 · 运行时未启动",
     "unknown": "未知",
     "error": "错误",
     "none": "无",
@@ -37,7 +38,7 @@
     "pendingUpdate": "有更新待生效",
     "hotplug": "立即生效",
     "hotplugOff": "已停用",
-    "hotplugNote": "已启用，新启动的应用将加载该模块",
+    "hotplugNote": "已应用，设备即将重启以完成激活",
     "hotplugToggle": "已热插拔（可拔）"
   },
   "fn": {

--- a/zygiskd/webui/src/types.ts
+++ b/zygiskd/webui/src/types.ts
@@ -12,11 +12,16 @@ export type BridgeHost = "ksu" | "mmrl" | null;
 
 /** The `key=value` header block of the status script output. */
 export interface StatusKeys {
+  status_protocol?: string;
+  installed?: string;
+  runtime?: string;
   version?: string;
   root?: string;
   z64?: string;
   z32?: string;
   daemon?: string;
+  hotplug?: string;
+  mount_mode?: string;
   workdir?: string;
   [key: string]: string | undefined;
 }


### PR DESCRIPTION
… fail-safe

Hot-plug activation: cold reboot instead of soft system_server restart
- The soft-restart path (SIGKILL system_server, let init re-fork) was unsafe on devices whose init escalates repeated zygote/netd restarts into a hard reboot: a module misbehaving on the soft-restarted framework looped the whole device.
- Replace restart_system_server_once() with reboot_device_to_activate(): trigger a full cold reboot via sys.powerctl=reboot (fallback: `reboot`). The cold boot re-runs the entire injection chain against a fresh zygote — the same, well-tested path a module takes after a normal install — and reliably lands the module in the new system_server.
- Guard state machine extended to survive the intentional reboot: rebooting (set on trigger) -> confirming (next boot, daemon startup) -> observing (first SystemServerStarted) -> cleared (stable window) A reboot that crosses 'confirming' without ever reaching SystemServerStarted means the module broke the boot path; it is unplugged at the next startup.

Cross-boot circuit breaker
- zygisk-init.sh no longer deletes hotplug_restart_guard; the daemon resolves a stale guard at startup (resolve_stale_restart_guard) and unplugs the named module before its library is served anywhere.
- module.cpp: send SystemServerStarted BEFORE run_modules_pre so the breaker still gets a heartbeat if the module crashes/hangs during load.
- zygiskd.rs: SystemServerStarted handler runs the breaker first; a failed controller notification no longer skips it.

Boot-loop fail-safe
- zygisk-init.sh increments boot_fail_count each boot; >=3 consecutive unhealthy boots latch injection_disabled.
- service.sh is the health witness: clears the counter after 120s uptime.
- ptracer/main.cpp: when injection_disabled is present, skip ptrace/ injection entirely (Magisk-style safe mode) until the user removes the flag.

Remote in-process custom loader (KSU LKM late-load fix)
- loader/src/ptracer/remote_csoloader.{cpp,hpp}: map libzygisk.so into the tracee via raw remote syscalls without going through the bionic linker, bypassing the namespace allowlist that rejected path-based dlopen on some KernelSU LKM late-load setups. Adapted from PerformanC/ReZygisk (GPL-3.0), conveyed under AGPL-3.0 per GPL-3.0 §13.
- ptracer.cpp / utils.cpp / utils.hpp / zygote_abi.cpp: rewired to the remote-syscall primitives.

WebUI
- ModulesSection / system.ts: hot-plug apply now reboots the device; updated comments and user-facing notes (zh/en/ja) accordingly.
- App.vue, LogsSection, useMonitorState, bridge, types: accompanying state and API updates.
- Tests refreshed for the new apply semantics.

Build
- build.gradle.kts, module/build.gradle.kts: minor config sync.
- webui/package.json: dependency bump.